### PR TITLE
Add PvP kill feed HUD with weapon icon

### DIFF
--- a/HMG/src/main/java/handmadeguns/HMGPacketHandler.java
+++ b/HMG/src/main/java/handmadeguns/HMGPacketHandler.java
@@ -55,6 +55,8 @@ public class HMGPacketHandler {
                 Side.SERVER);
         INSTANCE.registerMessage(MessageCatch_PlaySound_Gui.class, PacketPlaySound_Gui.class, ++id,
                 Side.CLIENT);
+        INSTANCE.registerMessage(MessageCatch_KillFeedEntry.class, PacketKillFeedEntry.class, ++id,
+                Side.CLIENT);
         INSTANCE.registerMessage(MessageCatch_SetElevation.class, PacketSetElevation.class, ++id,
                 Side.SERVER);
     }

--- a/HMG/src/main/java/handmadeguns/Handler/MessageCatch_KillFeedEntry.java
+++ b/HMG/src/main/java/handmadeguns/Handler/MessageCatch_KillFeedEntry.java
@@ -1,0 +1,15 @@
+package handmadeguns.Handler;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import handmadeguns.event.KillFeedHUD;
+import handmadeguns.network.PacketKillFeedEntry;
+
+public class MessageCatch_KillFeedEntry implements IMessageHandler<PacketKillFeedEntry, IMessage> {
+    @Override
+    public IMessage onMessage(PacketKillFeedEntry message, MessageContext ctx) {
+        KillFeedHUD.addEntry(message.attackerName, message.victimName, message.weaponStack);
+        return null;
+    }
+}

--- a/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java
+++ b/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java
@@ -23,6 +23,7 @@ import handmadeguns.Util.sendEntitydata;
 import handmadeguns.entity.*;
 import handmadeguns.network.PacketFixClientbullet;
 import handmadeguns.network.PacketSpawnParticle;
+import handmadeguns.network.PacketKillFeedEntry;
 import handmadevehicle.HMVChunkLoaderManager;
 import handmadevehicle.Utils;
 import io.netty.buffer.ByteBuf;
@@ -532,6 +533,14 @@ public class HMGEntityBulletBase extends Entity implements IEntityAdditionalSpaw
 				if(this.getThrower() != null&&getThrower() instanceof EntityPlayerMP){
 					HMGPacketHandler.INSTANCE.sendTo(new HMGMessageKeyPressedC(10, this.getThrower().getEntityId()),(EntityPlayerMP)this.getThrower());
 				}
+
+				if (this.getThrower() instanceof EntityPlayer && var1.entityHit instanceof EntityPlayer && var1.entityHit.isDead) {
+					EntityPlayer attacker = (EntityPlayer) this.getThrower();
+					EntityPlayer victim = (EntityPlayer) var1.entityHit;
+					ItemStack weapon = attacker.getHeldItem();
+					HMGPacketHandler.INSTANCE.sendToAll(new PacketKillFeedEntry(attacker.getDisplayName(), victim.getDisplayName(), weapon));
+				}
+
 				this.setDead();
 			}
 			if(var1.entityHit instanceof EntityLiving)for (int i = 0; i < 4; ++i) {

--- a/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
+++ b/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
@@ -6,6 +6,7 @@ import handmadeguns.entity.PlacedGunEntity;
 import handmadeguns.items.*;
 import handmadeguns.items.guns.*;
 import handmadeguns.event.AmmoHUDRenderer;
+import handmadeguns.event.KillFeedHUD;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.*;
 import net.minecraft.entity.Entity;
@@ -810,6 +811,7 @@ public class HMGEventZoom {
 			}
 			GL11.glPopAttrib();
 			GL11.glPopMatrix();
+			KillFeedHUD.render(minecraft);
 			previtemstack = gunstack;
 		}
 

--- a/HMG/src/main/java/handmadeguns/event/KillFeedHUD.java
+++ b/HMG/src/main/java/handmadeguns/event/KillFeedHUD.java
@@ -1,0 +1,73 @@
+package handmadeguns.event;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class KillFeedHUD {
+    private static final List<KillEntry> ENTRIES = new ArrayList<KillEntry>();
+    private static final int DISPLAY_TICKS = 120;
+
+    public static void addEntry(String attacker, String victim, ItemStack weapon) {
+        ItemStack copy = weapon == null ? null : weapon.copy();
+        ENTRIES.add(0, new KillEntry(attacker, victim, copy, DISPLAY_TICKS));
+        while (ENTRIES.size() > 5) {
+            ENTRIES.remove(ENTRIES.size() - 1);
+        }
+    }
+
+    public static void render(Minecraft minecraft) {
+        if (ENTRIES.isEmpty()) return;
+
+        ScaledResolution scaled = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+        FontRenderer font = minecraft.fontRenderer;
+        int x = scaled.getScaledWidth() - 170;
+        int y = 20;
+
+        Iterator<KillEntry> it = ENTRIES.iterator();
+        int row = 0;
+        while (it.hasNext()) {
+            KillEntry entry = it.next();
+            entry.ticksLeft--;
+            if (entry.ticksLeft <= 0) {
+                it.remove();
+                continue;
+            }
+
+            int rowY = y + (row * 20);
+            Gui.drawRect(x - 4, rowY - 2, x + 164, rowY + 16, 0x66000000);
+            font.drawStringWithShadow(entry.attacker, x, rowY + 4, 0xFF5555);
+            if (entry.weapon != null) {
+                GL11.glPushMatrix();
+                RenderHelper.enableGUIStandardItemLighting();
+                minecraft.getRenderItem().renderItemAndEffectIntoGUI(font, minecraft.renderEngine, entry.weapon, x + 74, rowY);
+                RenderHelper.disableStandardItemLighting();
+                GL11.glPopMatrix();
+            }
+            font.drawStringWithShadow(entry.victim, x + 96, rowY + 4, 0x55AAFF);
+            row++;
+        }
+    }
+
+    private static class KillEntry {
+        final String attacker;
+        final String victim;
+        final ItemStack weapon;
+        int ticksLeft;
+
+        KillEntry(String attacker, String victim, ItemStack weapon, int ticksLeft) {
+            this.attacker = attacker;
+            this.victim = victim;
+            this.weapon = weapon;
+            this.ticksLeft = ticksLeft;
+        }
+    }
+}

--- a/HMG/src/main/java/handmadeguns/network/PacketKillFeedEntry.java
+++ b/HMG/src/main/java/handmadeguns/network/PacketKillFeedEntry.java
@@ -1,0 +1,39 @@
+package handmadeguns.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.item.ItemStack;
+
+import static cpw.mods.fml.common.network.ByteBufUtils.readItemStack;
+import static cpw.mods.fml.common.network.ByteBufUtils.readUTF8String;
+import static cpw.mods.fml.common.network.ByteBufUtils.writeItemStack;
+import static cpw.mods.fml.common.network.ByteBufUtils.writeUTF8String;
+
+public class PacketKillFeedEntry implements IMessage {
+    public String attackerName;
+    public String victimName;
+    public ItemStack weaponStack;
+
+    public PacketKillFeedEntry() {
+    }
+
+    public PacketKillFeedEntry(String attackerName, String victimName, ItemStack weaponStack) {
+        this.attackerName = attackerName;
+        this.victimName = victimName;
+        this.weaponStack = weaponStack;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        attackerName = readUTF8String(buf);
+        victimName = readUTF8String(buf);
+        weaponStack = readItemStack(buf);
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        writeUTF8String(buf, attackerName);
+        writeUTF8String(buf, victimName);
+        writeItemStack(buf, weaponStack);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an in-game, client-side kill feed for player-vs-player kills so players can see who killed whom and which weapon icon was used. 
- Keep all changes confined to the `HMG/` module as requested.

### Description
- Add a clientbound packet `PacketKillFeedEntry` that carries attacker name, victim name and the weapon `ItemStack` (`HMG/src/main/java/handmadeguns/network/PacketKillFeedEntry.java`).
- Add a client handler `MessageCatch_KillFeedEntry` that pushes received entries into the HUD queue (`HMG/src/main/java/handmadeguns/Handler/MessageCatch_KillFeedEntry.java`).
- Register the new packet in `HMGPacketHandler` so clients receive kill-feed entries (`HMG/src/main/java/handmadeguns/HMGPacketHandler.java`).
- Detect PvP kills server-side during bullet impact in `HMGEntityBulletBase` and broadcast `PacketKillFeedEntry` to all clients when a player kills another player (`HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java`).
- Implement `KillFeedHUD` to render recent entries on the screen with attacker at left, weapon icon centered, and victim at right, including time-based expiry and max entries (`HMG/src/main/java/handmadeguns/event/KillFeedHUD.java`).
- Hook the `KillFeedHUD.render(...)` call into the existing HMG HUD overlay render path so the feed is drawn during normal HUD rendering (`HMG/src/main/java/handmadeguns/event/HMGEventZoom.java`).

### Testing
- Ran `git status --short` to verify changes are staged/committed; the repository shows the expected changed and added files (succeeded). 
- No build or runtime/CI tests were executed in this change; compilation and in-game verification remain to be run in an appropriate environment (not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d46bccf4c8329960bf76660205fec)