### PR TITLE
Add player kill feed HUD with networking and handler

### DIFF
--- a/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
+++ b/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
@@ -14,6 +14,7 @@ import handmadeguns.client.modelLoader.emb_modelloader.MQO_ModelLoader;
 import handmadeguns.entity.*;
 import handmadeguns.entity.bullets.*;
 import handmadeguns.event.HMGFovHandler;
+import handmadeguns.event.KillFeedHUD;
 import handmadeguns.items.guns.HMGItem_Unified_Guns;
 import handmadeguns.network.PacketSpawnParticle;
 import handmadeguns.client.render.*;
@@ -161,6 +162,11 @@ public class ClientProxyHMG extends CommonSideProxyHMG {
 	public void playGUISound(String sound,float speed){
 		getMCInstance().getSoundHandler().playSound(PositionedSoundRecord.func_147673_a(new ResourceLocation(sound)));
 	}
+	@Override
+	public void addKillFeedEntry(String attacker, String victim, ItemStack weapon) {
+		KillFeedHUD.addEntry(attacker, victim, weapon);
+	}
+
 	@Override
 	public World getCilentWorld(){
 		return FMLClientHandler.instance().getClient().theWorld;

--- a/HMG/src/main/java/handmadeguns/CommonSideProxyHMG.java
+++ b/HMG/src/main/java/handmadeguns/CommonSideProxyHMG.java
@@ -170,4 +170,7 @@ public class CommonSideProxyHMG {
 	}
 	public void AddModel(Object o){
 	}
+
+	public void addKillFeedEntry(String attacker, String victim, ItemStack weapon) {
+	}
 }

--- a/HMG/src/main/java/handmadeguns/HMGPacketHandler.java
+++ b/HMG/src/main/java/handmadeguns/HMGPacketHandler.java
@@ -55,6 +55,8 @@ public class HMGPacketHandler {
                 Side.SERVER);
         INSTANCE.registerMessage(MessageCatch_PlaySound_Gui.class, PacketPlaySound_Gui.class, ++id,
                 Side.CLIENT);
+        INSTANCE.registerMessage(MessageCatch_KillFeedEntry.class, PacketKillFeedEntry.class, ++id,
+                Side.CLIENT);
         INSTANCE.registerMessage(MessageCatch_SetElevation.class, PacketSetElevation.class, ++id,
                 Side.SERVER);
     }

--- a/HMG/src/main/java/handmadeguns/Handler/MessageCatch_KillFeedEntry.java
+++ b/HMG/src/main/java/handmadeguns/Handler/MessageCatch_KillFeedEntry.java
@@ -1,0 +1,14 @@
+package handmadeguns.Handler;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import handmadeguns.network.PacketKillFeedEntry;
+
+public class MessageCatch_KillFeedEntry implements IMessageHandler<PacketKillFeedEntry, IMessage> {
+    @Override
+    public IMessage onMessage(PacketKillFeedEntry message, MessageContext ctx) {
+        handmadeguns.HandmadeGunsCore.HMG_proxy.addKillFeedEntry(message.attackerName, message.victimName, message.weaponStack);
+        return null;
+    }
+}

--- a/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java
+++ b/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java
@@ -23,6 +23,7 @@ import handmadeguns.Util.sendEntitydata;
 import handmadeguns.entity.*;
 import handmadeguns.network.PacketFixClientbullet;
 import handmadeguns.network.PacketSpawnParticle;
+import handmadeguns.network.PacketKillFeedEntry;
 import handmadevehicle.HMVChunkLoaderManager;
 import handmadevehicle.Utils;
 import io.netty.buffer.ByteBuf;
@@ -489,6 +490,8 @@ public class HMGEntityBulletBase extends Entity implements IEntityAdditionalSpaw
 			}
 			var1.entityHit.hurtResistantTime = 0;
 
+			boolean victimWasAlive = !(var1.entityHit instanceof EntityPlayer) || ((EntityPlayer)var1.entityHit).getHealth() > 0.0F;
+
 			double moXback = var1.entityHit.motionX;
 			double moYback = var1.entityHit.motionY;
 			double moZback = var1.entityHit.motionZ;
@@ -532,6 +535,17 @@ public class HMGEntityBulletBase extends Entity implements IEntityAdditionalSpaw
 				if(this.getThrower() != null&&getThrower() instanceof EntityPlayerMP){
 					HMGPacketHandler.INSTANCE.sendTo(new HMGMessageKeyPressedC(10, this.getThrower().getEntityId()),(EntityPlayerMP)this.getThrower());
 				}
+
+				if (this.getThrower() instanceof EntityPlayer && var1.entityHit instanceof EntityPlayer) {
+					EntityPlayer attacker = (EntityPlayer) this.getThrower();
+					EntityPlayer victim = (EntityPlayer) var1.entityHit;
+					boolean victimNowDead = victim.isDead || victim.getHealth() <= 0.0F;
+					if (victimWasAlive && victimNowDead) {
+						ItemStack weapon = attacker.getHeldItem();
+						HMGPacketHandler.INSTANCE.sendToAll(new PacketKillFeedEntry(attacker.getDisplayName(), victim.getDisplayName(), weapon));
+					}
+				}
+
 				this.setDead();
 			}
 			if(var1.entityHit instanceof EntityLiving)for (int i = 0; i < 4; ++i) {

--- a/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
+++ b/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
@@ -6,6 +6,7 @@ import handmadeguns.entity.PlacedGunEntity;
 import handmadeguns.items.*;
 import handmadeguns.items.guns.*;
 import handmadeguns.event.AmmoHUDRenderer;
+import handmadeguns.event.KillFeedHUD;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.*;
 import net.minecraft.entity.Entity;
@@ -810,6 +811,7 @@ public class HMGEventZoom {
 			}
 			GL11.glPopAttrib();
 			GL11.glPopMatrix();
+			KillFeedHUD.render(minecraft);
 			previtemstack = gunstack;
 		}
 

--- a/HMG/src/main/java/handmadeguns/event/KillFeedHUD.java
+++ b/HMG/src/main/java/handmadeguns/event/KillFeedHUD.java
@@ -1,0 +1,88 @@
+package handmadeguns.event;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@SideOnly(Side.CLIENT)
+public class KillFeedHUD {
+    private static final List<KillEntry> ENTRIES = new ArrayList<KillEntry>();
+    private static final int DISPLAY_TICKS = 120;
+
+    public static void addEntry(String attacker, String victim, ItemStack weapon) {
+        ItemStack copy = weapon == null ? null : weapon.copy();
+        ENTRIES.add(0, new KillEntry(attacker, victim, copy, DISPLAY_TICKS));
+        while (ENTRIES.size() > 5) {
+            ENTRIES.remove(ENTRIES.size() - 1);
+        }
+    }
+
+    public static void render(Minecraft minecraft) {
+        if (ENTRIES.isEmpty()) return;
+
+        ScaledResolution scaled = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+        FontRenderer font = minecraft.fontRenderer;
+        int x = scaled.getScaledWidth() - 170;
+        int y = (scaled.getScaledHeight() / 2) - 50;
+
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glPushMatrix();
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        GL11.glDepthMask(false);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+
+        Iterator<KillEntry> it = ENTRIES.iterator();
+        int row = 0;
+        while (it.hasNext()) {
+            KillEntry entry = it.next();
+            entry.ticksLeft--;
+            if (entry.ticksLeft <= 0) {
+                it.remove();
+                continue;
+            }
+
+            int rowY = y + (row * 20);
+            Gui.drawRect(x - 4, rowY - 2, x + 164, rowY + 16, 0x4A000000);
+            font.drawStringWithShadow(entry.attacker, x, rowY + 4, 0xFF5555);
+            if (entry.weapon != null) {
+                GL11.glPushMatrix();
+                RenderHelper.enableGUIStandardItemLighting();
+                minecraft.renderItem.renderItemAndEffectIntoGUI(font, minecraft.renderEngine, entry.weapon, x + 74, rowY);
+                RenderHelper.disableStandardItemLighting();
+                GL11.glPopMatrix();
+            }
+            font.drawStringWithShadow(entry.victim, x + 96, rowY + 4, 0x55AAFF);
+            row++;
+        }
+
+        GL11.glDepthMask(true);
+        GL11.glPopMatrix();
+        GL11.glPopAttrib();
+    }
+
+    private static class KillEntry {
+        final String attacker;
+        final String victim;
+        final ItemStack weapon;
+        int ticksLeft;
+
+        KillEntry(String attacker, String victim, ItemStack weapon, int ticksLeft) {
+            this.attacker = attacker;
+            this.victim = victim;
+            this.weapon = weapon;
+            this.ticksLeft = ticksLeft;
+        }
+    }
+}

--- a/HMG/src/main/java/handmadeguns/network/PacketKillFeedEntry.java
+++ b/HMG/src/main/java/handmadeguns/network/PacketKillFeedEntry.java
@@ -1,0 +1,39 @@
+package handmadeguns.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.item.ItemStack;
+
+import static cpw.mods.fml.common.network.ByteBufUtils.readItemStack;
+import static cpw.mods.fml.common.network.ByteBufUtils.readUTF8String;
+import static cpw.mods.fml.common.network.ByteBufUtils.writeItemStack;
+import static cpw.mods.fml.common.network.ByteBufUtils.writeUTF8String;
+
+public class PacketKillFeedEntry implements IMessage {
+    public String attackerName;
+    public String victimName;
+    public ItemStack weaponStack;
+
+    public PacketKillFeedEntry() {
+    }
+
+    public PacketKillFeedEntry(String attackerName, String victimName, ItemStack weaponStack) {
+        this.attackerName = attackerName;
+        this.victimName = victimName;
+        this.weaponStack = weaponStack;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        attackerName = readUTF8String(buf);
+        victimName = readUTF8String(buf);
+        weaponStack = readItemStack(buf);
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        writeUTF8String(buf, attackerName);
+        writeUTF8String(buf, victimName);
+        writeItemStack(buf, weaponStack);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an in-game kill feed that shows attacker, victim and weapon icon for player-vs-player kills.
- Propagate kill events from server-side bullet impacts to clients so the HUD can display them.

### Description

- Added a new client-side HUD renderer `handmadeguns.event.KillFeedHUD` which stores entries and renders name + weapon icon on-screen.
- Introduced a network packet `handmadeguns.network.PacketKillFeedEntry` and server-to-client message handler `handmadeguns.Handler.MessageCatch_KillFeedEntry` to transport kill data to clients.
- Registered the new message in `HMGPacketHandler` and added a proxy API `addKillFeedEntry` to `ClientProxyHMG`/`CommonSideProxyHMG` that forwards to `KillFeedHUD.addEntry`.
- Emitted the kill-feed packet from `HMGEntityBulletBase` when a player bullet causes another player to die, and hooked `KillFeedHUD.render` into `HMGEventZoom` to draw the feed during HUD rendering.

### Testing

- Ran a full project build with `gradlew build` and the project compiled successfully with the new classes and registrations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d46bccf4c8329960bf76660205fec)