### PR TITLE
Smooth recoil: spring-damped camera kick

### DIFF
--- a/HMG/src/main/java/handmadeguns/Handler/MessageCatchRecoilOrder.java
+++ b/HMG/src/main/java/handmadeguns/Handler/MessageCatchRecoilOrder.java
@@ -7,6 +7,7 @@ import handmadeguns.items.HMGItemAttachment_grip;
 import handmadeguns.items.guns.HMGItem_Unified_Guns;
 import handmadeguns.HandmadeGunsCore;
 import handmadeguns.network.PacketRecoil;
+import handmadeguns.event.RenderTickSmoothing;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -59,11 +60,11 @@ public class MessageCatchRecoilOrder implements IMessageHandler<PacketRecoil, IM
                         if(HandmadeGunsCore.Key_ADS(entityPlayer)){ //grip recoil
                             if(items[4] != null && items[4].getItem() instanceof HMGItemAttachment_grip)
                                 reduceRecoilLevel = ((HMGItemAttachment_grip) items[4].getItem()).reduceRecoilLevel_ADS;
-                            entityPlayer.rotationPitch -= ((HMGItem_Unified_Guns) item).gunInfo.recoil_sneak * reduceRecoilLevel;
+                            RenderTickSmoothing.addSmoothRecoilPitch((float) (((HMGItem_Unified_Guns) item).gunInfo.recoil_sneak * reduceRecoilLevel));
                         }else {
                             if(items[4] != null && items[4].getItem() instanceof HMGItemAttachment_grip)
                                 reduceRecoilLevel = ((HMGItemAttachment_grip) items[4].getItem()).reduceRecoilLevel;
-                            entityPlayer.rotationPitch -= ((HMGItem_Unified_Guns) item).gunInfo.recoil * reduceRecoilLevel;
+                            RenderTickSmoothing.addSmoothRecoilPitch((float) (((HMGItem_Unified_Guns) item).gunInfo.recoil * reduceRecoilLevel));
                         }
                     }
                 }

--- a/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
+++ b/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
@@ -42,6 +42,15 @@ public class RenderTickSmoothing {
 	public static int currentRenderBuffer = -1;
 	public static int currentTextureBuffer = -1;
 	public static int currentStencilBufferID = -1;
+	private static float pendingRecoilPitch = 0.0f;
+	private static float recoilVelocityPitch = 0.0f;
+	private static final float RECOIL_SPRING = 0.30f;
+	private static final float RECOIL_DAMPING = 0.72f;
+
+	public static void addSmoothRecoilPitch(float recoilAmount)
+	{
+		pendingRecoilPitch += recoilAmount;
+	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void renderTick(TickEvent.RenderTickEvent event)
@@ -177,6 +186,7 @@ public class RenderTickSmoothing {
 
 		if (HMG_proxy.getEntityPlayerInstance() == null) return;
 		EntityPlayer entityPlayer = HMG_proxy.getEntityPlayerInstance();
+		applySmoothRecoil(entityPlayer);
 
 		ItemStack held = entityPlayer.getCurrentEquippedItem();
 
@@ -285,6 +295,24 @@ public class RenderTickSmoothing {
 		//		}
 		//	}
 		//}
+	}
+
+	private void applySmoothRecoil(EntityPlayer entityPlayer)
+	{
+		if (entityPlayer == null) return;
+		if (pendingRecoilPitch == 0.0f && recoilVelocityPitch == 0.0f) return;
+
+		recoilVelocityPitch += pendingRecoilPitch;
+		pendingRecoilPitch = 0.0f;
+
+		float recoilStep = recoilVelocityPitch * RECOIL_SPRING;
+		recoilVelocityPitch *= RECOIL_DAMPING;
+
+		if (Math.abs(recoilVelocityPitch) < 0.001f) {
+			recoilVelocityPitch = 0.0f;
+		}
+
+		entityPlayer.rotationPitch -= recoilStep;
 	}
 
 


### PR DESCRIPTION
### Motivation
- Replace the instantaneous camera snap currently applied on fire with a smoother, more natural recoil impulse similar to Modern Warfare-style kicks. 
- Keep all existing recoil tuning and attachment scaling intact so the change is automatic and preserves current weapon balance.

### Description
- Added queued recoil state and integration parameters (`pendingRecoilPitch`, `recoilVelocityPitch`, `RECOIL_SPRING`, `RECOIL_DAMPING`) and an API `addSmoothRecoilPitch(float)` in `RenderTickSmoothing` to accumulate recoil events. 
- Replaced direct `rotationPitch` mutations in `MessageCatchRecoilOrder` with calls to `RenderTickSmoothing.addSmoothRecoilPitch(...)` so ADS/hipfire recoil and grip reduction levels are preserved. 
- Applied per-tick spring-damped integration via a new `applySmoothRecoil(EntityPlayer)` invoked from the existing `clientTickEvent`, which consumes the queued recoil into a smoothed camera pitch change. 
- The system uses the configured gun `gunInfo.recoil` / `gunInfo.recoil_sneak` values and attachment multipliers as input, so no weapon tuning changes were required.

### Testing
- Ran `./gradlew :HMG:compileJava -q` in the environment, which failed with `Permission denied` because the wrapper file was not executable. 
- Ran `bash ./gradlew :HMG:compileJava -q` to force execution, which failed during Gradle download due to a network/proxy restriction (`HTTP 403`), so full compilation could not be completed in this environment. 
- No automated unit or runtime tests were available or executed after the compile attempts due to the above failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4d74496083299737e06a3248347a)