### PR TITLE
Implement smooth recoil smoothing system and route recoil through renderer

### DIFF
--- a/HMG/src/main/java/handmadeguns/Handler/MessageCatchRecoilOrder.java
+++ b/HMG/src/main/java/handmadeguns/Handler/MessageCatchRecoilOrder.java
@@ -7,6 +7,7 @@ import handmadeguns.items.HMGItemAttachment_grip;
 import handmadeguns.items.guns.HMGItem_Unified_Guns;
 import handmadeguns.HandmadeGunsCore;
 import handmadeguns.network.PacketRecoil;
+import handmadeguns.event.RenderTickSmoothing;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -59,11 +60,11 @@ public class MessageCatchRecoilOrder implements IMessageHandler<PacketRecoil, IM
                         if(HandmadeGunsCore.Key_ADS(entityPlayer)){ //grip recoil
                             if(items[4] != null && items[4].getItem() instanceof HMGItemAttachment_grip)
                                 reduceRecoilLevel = ((HMGItemAttachment_grip) items[4].getItem()).reduceRecoilLevel_ADS;
-                            entityPlayer.rotationPitch -= ((HMGItem_Unified_Guns) item).gunInfo.recoil_sneak * reduceRecoilLevel;
+                            RenderTickSmoothing.addSmoothRecoil((float) (((HMGItem_Unified_Guns) item).gunInfo.recoil_sneak * reduceRecoilLevel));
                         }else {
                             if(items[4] != null && items[4].getItem() instanceof HMGItemAttachment_grip)
                                 reduceRecoilLevel = ((HMGItemAttachment_grip) items[4].getItem()).reduceRecoilLevel;
-                            entityPlayer.rotationPitch -= ((HMGItem_Unified_Guns) item).gunInfo.recoil * reduceRecoilLevel;
+                            RenderTickSmoothing.addSmoothRecoil((float) (((HMGItem_Unified_Guns) item).gunInfo.recoil * reduceRecoilLevel));
                         }
                     }
                 }

--- a/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
+++ b/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
@@ -17,6 +17,7 @@ import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.EXTFramebufferObject;
 
 import java.nio.FloatBuffer;
+import java.util.Random;
 
 import static handmadeguns.HandmadeGunsCore.HMG_proxy;
 import static handmadeguns.HandmadeGunsCore.cfg_Sneak_ByADSKey;
@@ -42,6 +43,27 @@ public class RenderTickSmoothing {
 	public static int currentRenderBuffer = -1;
 	public static int currentTextureBuffer = -1;
 	public static int currentStencilBufferID = -1;
+	private static float pendingRecoilPitch = 0.0f;
+	private static float pendingRecoilYaw = 0.0f;
+	private static float recoilVelocityPitch = 0.0f;
+	private static float recoilVelocityYaw = 0.0f;
+	private static final float RECOIL_SPRING = 0.48f;
+	private static final float RECOIL_DAMPING = 0.76f;
+	private static final float HORIZONTAL_RECOIL_RATIO = 0.15f;
+	private static final Random RECOIL_RANDOM = new Random();
+
+	public static void addSmoothRecoilPitch(float recoilAmount)
+	{
+		addSmoothRecoil(recoilAmount);
+	}
+
+	public static void addSmoothRecoil(float recoilPitchAmount)
+	{
+		float horizontalSign = RECOIL_RANDOM.nextBoolean() ? 1.0f : -1.0f;
+		float recoilYawAmount = recoilPitchAmount * HORIZONTAL_RECOIL_RATIO * horizontalSign;
+		pendingRecoilPitch += recoilPitchAmount;
+		pendingRecoilYaw += recoilYawAmount;
+	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void renderTick(TickEvent.RenderTickEvent event)
@@ -177,6 +199,7 @@ public class RenderTickSmoothing {
 
 		if (HMG_proxy.getEntityPlayerInstance() == null) return;
 		EntityPlayer entityPlayer = HMG_proxy.getEntityPlayerInstance();
+		applySmoothRecoil(entityPlayer);
 
 		ItemStack held = entityPlayer.getCurrentEquippedItem();
 
@@ -285,6 +308,33 @@ public class RenderTickSmoothing {
 		//		}
 		//	}
 		//}
+	}
+
+	private void applySmoothRecoil(EntityPlayer entityPlayer)
+	{
+		if (entityPlayer == null) return;
+		if (pendingRecoilPitch == 0.0f && recoilVelocityPitch == 0.0f
+				&& pendingRecoilYaw == 0.0f && recoilVelocityYaw == 0.0f) return;
+
+		recoilVelocityPitch += pendingRecoilPitch;
+		recoilVelocityYaw += pendingRecoilYaw;
+		pendingRecoilPitch = 0.0f;
+		pendingRecoilYaw = 0.0f;
+
+		float recoilStepPitch = recoilVelocityPitch * RECOIL_SPRING;
+		float recoilStepYaw = recoilVelocityYaw * RECOIL_SPRING;
+		recoilVelocityPitch *= RECOIL_DAMPING;
+		recoilVelocityYaw *= RECOIL_DAMPING;
+
+		if (Math.abs(recoilVelocityPitch) < 0.001f) {
+			recoilVelocityPitch = 0.0f;
+		}
+		if (Math.abs(recoilVelocityYaw) < 0.001f) {
+			recoilVelocityYaw = 0.0f;
+		}
+
+		entityPlayer.rotationPitch -= recoilStepPitch;
+		entityPlayer.rotationYaw += recoilStepYaw;
 	}
 
 


### PR DESCRIPTION
### Motivation

- Avoid abrupt instantaneous camera jumps when firing by smoothing recoil application over frames using a spring-damper model.
- Centralize recoil handling to allow vertical and a small randomized horizontal recoil component to be applied consistently in the render/client tick.

### Description

- Replaced direct immediate pitch adjustments in `MessageCatchRecoilOrder` with calls to `RenderTickSmoothing.addSmoothRecoil(...)` and added the required import.
- Added recoil state and smoothing logic to `RenderTickSmoothing`, including pending recoil accumulators, velocity fields, spring/damping constants, a small horizontal recoil ratio, and an RNG for horizontal sign.
- Exposed `addSmoothRecoil` and `addSmoothRecoilPitch` APIs to enqueue recoil and applied the accumulated recoil each client tick via a new `applySmoothRecoil(EntityPlayer)` method which modifies `rotationPitch` and `rotationYaw` smoothly.
- Kept existing render and mouse-sensitivity handling intact while introducing the new smoothing pipeline.

### Testing

- Ran a full project build with `gradlew build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4d74496083299737e06a3248347a)