### PR TITLE
Smooth ADS/hipfire transition with eased interpolation

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
@@ -634,16 +634,16 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 						else if (prevSprintState && !nbt.getBoolean("set_up"))
 							setUpGunPos_equipe_sprint(0, 1 - smoothing);
 						else if (prevADSState)
-							setUpGunPos_ADS(-1.4F, 1 - smoothing);
+							setUpGunPos_ADS(-1.4F, getADSBlend(1 - smoothing));
 						else
 							setUpGunPos_equipe(0);
 					}
 					else if (firstPerson_ADSState && prevADSState)
 						setUpGunPos_ADS(-1.4F);
 					else if (firstPerson_ADSState)
-						setUpGunPos_ADS(-1.4F, smoothing);
+						setUpGunPos_ADS(-1.4F, getADSBlend(smoothing));
 					else if (prevADSState)
-						setUpGunPos_ADS(-1.4F, 1 - smoothing);
+						setUpGunPos_ADS(-1.4F, getADSBlend(1 - smoothing));
 					else if (firstPerson_SprintState && prevSprintState && !nbt.getBoolean("set_up"))
 						setUpGunPos_equipe_sprint(0, 1);
 					else if (firstPerson_SprintState && !nbt.getBoolean("set_up"))
@@ -837,6 +837,11 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 	public float getSmoothing(){
 		return smoothing;
+	}
+
+	private static float getADSBlend(float progress){
+		float clamped = MathHelper.clamp_float(progress, 0.0F, 1.0F);
+		return clamped * clamped * (3.0F - 2.0F * clamped);
 	}
 
 	public void bindPlayertexture(Entity entityplayer) {


### PR DESCRIPTION
### Motivation
- Make the first-person transition between hipfire and ADS less abrupt by easing the interpolation curve so the gun position ramps in/out smoothly.

### Description
- Added a `getADSBlend` helper (smoothstep-style) to `HMGRenderItemGun_U_NEW` to remap linear progress into an eased curve.
- Replaced linear `smoothing` usage in ADS entry/exit and the reload->ADS fallback with `getADSBlend(smoothing)` and `getADSBlend(1 - smoothing)` to soften both ends of the transition.

### Testing
- Patch applied to `HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java` and updated code validated in-tree; no automated unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116fe123348329bdce5202e8d4be25)