### PR TITLE
Smooth ADS transition and peripheral focus mask for scopes

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
@@ -47,6 +47,7 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 	public static boolean prevSprintState = false;
 	public static boolean firstPerson_ADSState = false;
 	public static boolean prevADSState = false;
+	private static float adsTransition = 0.0F;
 	public static boolean firstPerson_ReloadState = false;
 	public static boolean prevReloadState = false;
 	private static FloatBuffer colorBuffer = GLAllocation.createDirectFloatBuffer(16);
@@ -627,23 +628,23 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 					//boolean isreloading = this.getbooleanfromnbt("IsReloading");
 					//ununused?
+					updateADSProgress(firstPerson_ADSState);
+					float adsBlend = getADSBlend(adsTransition);
 					if (firstPerson_ReloadState)
 					{
 						if (prevReloadState)
 							setUpGunPos_equipe(0);
 						else if (prevSprintState && !nbt.getBoolean("set_up"))
 							setUpGunPos_equipe_sprint(0, 1 - smoothing);
-						else if (prevADSState)
-							setUpGunPos_ADS(-1.4F, 1 - smoothing);
+						else if (adsTransition > 0.0F)
+							setUpGunPos_ADS(-1.4F, adsBlend);
 						else
 							setUpGunPos_equipe(0);
 					}
-					else if (firstPerson_ADSState && prevADSState)
+					else if (adsTransition >= 0.999F)
 						setUpGunPos_ADS(-1.4F);
-					else if (firstPerson_ADSState)
-						setUpGunPos_ADS(-1.4F, smoothing);
-					else if (prevADSState)
-						setUpGunPos_ADS(-1.4F, 1 - smoothing);
+					else if (adsTransition > 0.0F)
+						setUpGunPos_ADS(-1.4F, adsBlend);
 					else if (firstPerson_SprintState && prevSprintState && !nbt.getBoolean("set_up"))
 						setUpGunPos_equipe_sprint(0, 1);
 					else if (firstPerson_SprintState && !nbt.getBoolean("set_up"))
@@ -837,6 +838,20 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 	public float getSmoothing(){
 		return smoothing;
+	}
+
+	private static float getADSBlend(float progress){
+		float clamped = MathHelper.clamp_float(progress, 0.0F, 1.0F);
+		return clamped * clamped * (3.0F - 2.0F * clamped);
+	}
+
+	private static void updateADSProgress(boolean adsActive){
+		float step = 0.18F;
+		if(adsActive){
+			adsTransition = Math.min(1.0F, adsTransition + step);
+		}else{
+			adsTransition = Math.max(0.0F, adsTransition - step);
+		}
 	}
 
 	public void bindPlayertexture(Entity entityplayer) {

--- a/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
+++ b/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
@@ -513,6 +513,7 @@ public class HMGEventZoom {
 											renderPumpkinBlur(minecraft, ads);
 											needreset = true;
 										}
+										renderPeripheralFocusMask(minecraft, 0.45F);
 									//}
 								}
 								if (gunItem.gunInfo.renderMCcross) {
@@ -1012,6 +1013,47 @@ public class HMGEventZoom {
 	public static void renderPumpkinBlur(Minecraft minecraft, String adss)
 	{
 		renderPumpkinBlur(minecraft,new ResourceLocation(adss));
+	}
+
+	private static void renderPeripheralFocusMask(Minecraft minecraft, float alpha){
+		ScaledResolution sr = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+		int width = sr.getScaledWidth();
+		int height = sr.getScaledHeight();
+		int cx = width / 2;
+		int cy = height / 2;
+		int halfHoleW = width / 10;
+		int halfHoleH = height / 8;
+
+		GL11.glDisable(GL11.GL_TEXTURE_2D);
+		GL11.glEnable(GL11.GL_BLEND);
+		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+		GL11.glColor4f(0.0F, 0.0F, 0.0F, alpha);
+
+		Tessellator tess = Tessellator.instance;
+		tess.startDrawingQuads();
+		// top
+		tess.addVertex(0, 0, -90);
+		tess.addVertex(width, 0, -90);
+		tess.addVertex(width, cy - halfHoleH, -90);
+		tess.addVertex(0, cy - halfHoleH, -90);
+		// bottom
+		tess.addVertex(0, cy + halfHoleH, -90);
+		tess.addVertex(width, cy + halfHoleH, -90);
+		tess.addVertex(width, height, -90);
+		tess.addVertex(0, height, -90);
+		// left
+		tess.addVertex(0, cy - halfHoleH, -90);
+		tess.addVertex(cx - halfHoleW, cy - halfHoleH, -90);
+		tess.addVertex(cx - halfHoleW, cy + halfHoleH, -90);
+		tess.addVertex(0, cy + halfHoleH, -90);
+		// right
+		tess.addVertex(cx + halfHoleW, cy - halfHoleH, -90);
+		tess.addVertex(width, cy - halfHoleH, -90);
+		tess.addVertex(width, cy + halfHoleH, -90);
+		tess.addVertex(cx + halfHoleW, cy + halfHoleH, -90);
+		tess.draw();
+
+		GL11.glEnable(GL11.GL_TEXTURE_2D);
 	}
 
 	@SideOnly(Side.CLIENT)


### PR DESCRIPTION
### Motivation

- Provide a smooth, eased transition when entering/exiting aim-down-sights (ADS) instead of abrupt state switches to improve visual fidelity.
- Add a peripheral focus (vignette) mask while not using a scoped overlay to better simulate focus on the sight area. 
- Centralize ADS progress state and easing to simplify positioning logic across first-person rendering.

### Description

- Add a new `adsTransition` field and helper methods `updateADSProgress(boolean)` and `getADSBlend(float)` to drive a smoothed ADS progress value using a smoothstep easing function. 
- Integrate the ADS progress into `HMGRenderItemGun_U_NEW` by calling `updateADSProgress(firstPerson_ADSState)` and replacing direct `firstPerson_ADSState`/`prevADSState` checks with `adsTransition` and `adsBlend` to control `setUpGunPos_ADS` calls. 
- Add `renderPeripheralFocusMask(Minecraft, float)` to `HMGEventZoom` and invoke it when appropriate to draw a translucent black mask with a clear rectangular central area, using GL state and `Tessellator` to render the peripheral overlay. 

### Testing

- Ran the project's automated build with `gradlew build`, which completed successfully and produced the compiled artifacts. 
- There are no repository-level automated unit tests executed by the build, so no additional test suites were run. 
- The changes were limited to client-side rendering code and compile-time checks passed during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116fe123348329bdce5202e8d4be25)