### PR TITLE
Smooth ADS transition and peripheral peripheral-focus mask for zoom rendering

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
@@ -47,6 +47,8 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 	public static boolean prevSprintState = false;
 	public static boolean firstPerson_ADSState = false;
 	public static boolean prevADSState = false;
+	private static float adsTransition = 0.0F;
+	private static long adsTransitionLastNanos = 0L;
 	public static boolean firstPerson_ReloadState = false;
 	public static boolean prevReloadState = false;
 	private static FloatBuffer colorBuffer = GLAllocation.createDirectFloatBuffer(16);
@@ -627,23 +629,23 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 					//boolean isreloading = this.getbooleanfromnbt("IsReloading");
 					//ununused?
+					updateADSProgress(firstPerson_ADSState);
+					float adsBlend = getADSBlend(adsTransition);
 					if (firstPerson_ReloadState)
 					{
 						if (prevReloadState)
 							setUpGunPos_equipe(0);
 						else if (prevSprintState && !nbt.getBoolean("set_up"))
 							setUpGunPos_equipe_sprint(0, 1 - smoothing);
-						else if (prevADSState)
-							setUpGunPos_ADS(-1.4F, 1 - smoothing);
+						else if (adsTransition > 0.0F)
+							setUpGunPos_ADS(-1.4F, adsBlend);
 						else
 							setUpGunPos_equipe(0);
 					}
-					else if (firstPerson_ADSState && prevADSState)
+					else if (adsTransition >= 0.999F)
 						setUpGunPos_ADS(-1.4F);
-					else if (firstPerson_ADSState)
-						setUpGunPos_ADS(-1.4F, smoothing);
-					else if (prevADSState)
-						setUpGunPos_ADS(-1.4F, 1 - smoothing);
+					else if (adsTransition > 0.0F)
+						setUpGunPos_ADS(-1.4F, adsBlend);
 					else if (firstPerson_SprintState && prevSprintState && !nbt.getBoolean("set_up"))
 						setUpGunPos_equipe_sprint(0, 1);
 					else if (firstPerson_SprintState && !nbt.getBoolean("set_up"))
@@ -837,6 +839,28 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 	public float getSmoothing(){
 		return smoothing;
+	}
+
+	private static float getADSBlend(float progress){
+		float clamped = MathHelper.clamp_float(progress, 0.0F, 1.0F);
+		return clamped * clamped * (3.0F - 2.0F * clamped);
+	}
+
+	private static void updateADSProgress(boolean adsActive){
+		long now = System.nanoTime();
+		if(adsTransitionLastNanos == 0L){
+			adsTransitionLastNanos = now;
+		}
+		float dt = (now - adsTransitionLastNanos) / 1000000000.0F;
+		adsTransitionLastNanos = now;
+		dt = MathHelper.clamp_float(dt, 0.0F, 0.05F);
+		float durationSec = 0.18F;
+		float step = dt / durationSec;
+		if(adsActive){
+			adsTransition = Math.min(1.0F, adsTransition + step);
+		}else{
+			adsTransition = Math.max(0.0F, adsTransition - step);
+		}
 	}
 
 	public void bindPlayertexture(Entity entityplayer) {

--- a/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
+++ b/HMG/src/main/java/handmadeguns/event/HMGEventZoom.java
@@ -513,6 +513,7 @@ public class HMGEventZoom {
 											renderPumpkinBlur(minecraft, ads);
 											needreset = true;
 										}
+										renderPeripheralFocusMask(minecraft, 0.70F);
 									//}
 								}
 								if (gunItem.gunInfo.renderMCcross) {
@@ -1012,6 +1013,50 @@ public class HMGEventZoom {
 	public static void renderPumpkinBlur(Minecraft minecraft, String adss)
 	{
 		renderPumpkinBlur(minecraft,new ResourceLocation(adss));
+	}
+
+	private static void renderPeripheralFocusMask(Minecraft minecraft, float alpha){
+		ScaledResolution sr = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+		int width = sr.getScaledWidth();
+		int height = sr.getScaledHeight();
+		int cx = width / 2;
+		int cy = height / 2;
+		int halfHoleW = width / 12;
+		int halfHoleH = height / 10;
+
+		GL11.glDisable(GL11.GL_TEXTURE_2D);
+		GL11.glEnable(GL11.GL_BLEND);
+		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+		drawPeripheralRect(width, height, cx, cy, halfHoleW + width / 9, halfHoleH + height / 9, alpha * 0.22F);
+		drawPeripheralRect(width, height, cx, cy, halfHoleW + width / 18, halfHoleH + height / 18, alpha * 0.35F);
+		drawPeripheralRect(width, height, cx, cy, halfHoleW, halfHoleH, alpha);
+
+		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GL11.glEnable(GL11.GL_TEXTURE_2D);
+		GL11.glDisable(GL11.GL_BLEND);
+	}
+
+	private static void drawPeripheralRect(int width, int height, int cx, int cy, int halfHoleW, int halfHoleH, float alpha){
+		GL11.glColor4f(0.0F, 0.0F, 0.0F, alpha);
+		Tessellator tess = Tessellator.instance;
+		tess.startDrawingQuads();
+		tess.addVertex(0, 0, -90);
+		tess.addVertex(width, 0, -90);
+		tess.addVertex(width, cy - halfHoleH, -90);
+		tess.addVertex(0, cy - halfHoleH, -90);
+		tess.addVertex(0, cy + halfHoleH, -90);
+		tess.addVertex(width, cy + halfHoleH, -90);
+		tess.addVertex(width, height, -90);
+		tess.addVertex(0, height, -90);
+		tess.addVertex(0, cy - halfHoleH, -90);
+		tess.addVertex(cx - halfHoleW, cy - halfHoleH, -90);
+		tess.addVertex(cx - halfHoleW, cy + halfHoleH, -90);
+		tess.addVertex(0, cy + halfHoleH, -90);
+		tess.addVertex(cx + halfHoleW, cy - halfHoleH, -90);
+		tess.addVertex(width, cy - halfHoleH, -90);
+		tess.addVertex(width, cy + halfHoleH, -90);
+		tess.addVertex(cx + halfHoleW, cy + halfHoleH, -90);
+		tess.draw();
 	}
 
 	@SideOnly(Side.CLIENT)


### PR DESCRIPTION
### Motivation

- Smooth abrupt aim-down-sights (ADS) transitions and replace brittle boolean checks with a time-based blend to improve visual feedback when entering/exiting ADS and when reloading.  
- Add a peripheral focus/vignette mask while zooming to emphasize the scoped area and reduce visual distraction.

### Description

- Added time-based ADS state with two new fields `adsTransition` and `adsTransitionLastNanos`, and implemented `updateADSProgress(boolean)` to incrementally advance the transition and `getADSBlend(float)` to produce a smooth cubic ease curve.  
- Integrated ADS progress into rendering by calling `updateADSProgress(firstPerson_ADSState)`, computing `adsBlend`, and using that blend when invoking `setUpGunPos_ADS(...)`, replacing many of the previous `prevADSState`/`firstPerson_ADSState` branching points.  
- Introduced `renderPeripheralFocusMask(Minecraft, float)` and helper `drawPeripheralRect(...)` to draw layered darkened regions around a centered hole; this is invoked from the zoom rendering path (`HMGEventZoom`) to apply a peripheral vignette when zooming.  
- Implemented OpenGL state handling for the mask (texture/blend enable/disable and alpha) and kept existing pumpkin/ads blur logic intact while adding the mask call.

### Testing

- Project build was executed via `./gradlew build` and completed successfully.  
- No new automated unit tests were added for rendering logic; existing automated build checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116fe123348329bdce5202e8d4be25)