### PR TITLE
Smooth ADS transition and fix hipfire jump in item gun renderer

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
@@ -47,6 +47,8 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 	public static boolean prevSprintState = false;
 	public static boolean firstPerson_ADSState = false;
 	public static boolean prevADSState = false;
+	private static float adsTransition = 0.0F;
+	private static long adsTransitionLastNanos = 0L;
 	public static boolean firstPerson_ReloadState = false;
 	public static boolean prevReloadState = false;
 	private static FloatBuffer colorBuffer = GLAllocation.createDirectFloatBuffer(16);
@@ -627,23 +629,23 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 					//boolean isreloading = this.getbooleanfromnbt("IsReloading");
 					//ununused?
+					updateADSProgress(firstPerson_ADSState);
+					float adsBlend = getADSBlend(adsTransition);
 					if (firstPerson_ReloadState)
 					{
 						if (prevReloadState)
 							setUpGunPos_equipe(0);
 						else if (prevSprintState && !nbt.getBoolean("set_up"))
 							setUpGunPos_equipe_sprint(0, 1 - smoothing);
-						else if (prevADSState)
-							setUpGunPos_ADS(-1.4F, 1 - smoothing);
+						else if (adsTransition > 0.0F)
+							setUpGunPos_ADS(-1.4F, adsBlend);
 						else
 							setUpGunPos_equipe(0);
 					}
-					else if (firstPerson_ADSState && prevADSState)
+					else if (adsTransition >= 0.999F)
 						setUpGunPos_ADS(-1.4F);
-					else if (firstPerson_ADSState)
-						setUpGunPos_ADS(-1.4F, smoothing);
-					else if (prevADSState)
-						setUpGunPos_ADS(-1.4F, 1 - smoothing);
+					else if (adsTransition > 0.0F)
+						setUpGunPos_ADS(-1.4F, adsBlend);
 					else if (firstPerson_SprintState && prevSprintState && !nbt.getBoolean("set_up"))
 						setUpGunPos_equipe_sprint(0, 1);
 					else if (firstPerson_SprintState && !nbt.getBoolean("set_up"))
@@ -770,7 +772,10 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 	public void setUpGunPos_ADS(float reco,float interPole) {
 		GL11.glRotatef(180f, 1.0F, 0.0F, 0.0F);
 		GL11.glRotatef(180f, 0.0F, 0.0F, 1.0F);
-		GL11.glTranslatef(modelPosX * (1 - interPole), modelPosY * (1 - interPole), (modelPosZ) * (1 - interPole));// -0.2F//-0.7,0.7,0
+		// Match the exact hipfire base transform while interpolating into ADS.
+		// Using modelPosZ without the +1.4f hipfire offset causes a small jump at
+		// transition start/end when the gun is resting off-center.
+		GL11.glTranslatef(modelPosX * (1 - interPole), modelPosY * (1 - interPole), (modelPosZ + 1.4f) * (1 - interPole));// -0.2F//-0.7,0.7,0
 
 		if(gunitem != null && nbt != null && gunitem.gunInfo.sightOffset_zeroIn != null && nbt.getInteger("currentElevation") >= 0 && gunitem.gunInfo.sightOffset_zeroIn.length>nbt.getInteger("currentElevation")) {
 			Vector3d sightOffset_zeroIn = gunitem.gunInfo.sightOffset_zeroIn[nbt.getInteger("currentElevation")];
@@ -837,6 +842,28 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 	public float getSmoothing(){
 		return smoothing;
+	}
+
+	private static float getADSBlend(float progress){
+		float clamped = MathHelper.clamp_float(progress, 0.0F, 1.0F);
+		return clamped * clamped * (3.0F - 2.0F * clamped);
+	}
+
+	private static void updateADSProgress(boolean adsActive){
+		long now = System.nanoTime();
+		if(adsTransitionLastNanos == 0L){
+			adsTransitionLastNanos = now;
+		}
+		float dt = (now - adsTransitionLastNanos) / 1000000000.0F;
+		adsTransitionLastNanos = now;
+		dt = MathHelper.clamp_float(dt, 0.0F, 0.05F);
+		float durationSec = 0.18F;
+		float step = MathHelper.clamp_float(dt / durationSec, 0.0F, 0.12F);
+		if(adsActive){
+			adsTransition = Math.min(1.0F, adsTransition + step);
+		}else{
+			adsTransition = Math.max(0.0F, adsTransition - step);
+		}
 	}
 
 	public void bindPlayertexture(Entity entityplayer) {


### PR DESCRIPTION
### Motivation
- Smooth the aim-down-sights (ADS) transition to remove visual popping when entering/exiting ADS.
- Replace abrupt state-based position switching with a time-based interpolation so animations feel natural.
- Fix a small positional jump by matching the hipfire base transform during ADS interpolation.

### Description
- Added `adsTransition` and `adsTransitionLastNanos` fields and implemented `updateADSProgress` to advance ADS progress over time using frame delta nanoseconds.
- Added `getADSBlend` to apply a smoothstep easing function to the raw transition progress and used `adsBlend` where interpolation is required.
- Replaced direct `firstPerson_ADSState`/`prevADSState` checks with logic that uses `adsTransition`/`adsBlend` when computing positions during reload and ADS setup, and called `updateADSProgress` each frame.
- Adjusted `setUpGunPos_ADS` to include the hipfire Z offset (`modelPosZ + 1.4f`) while interpolating to prevent a small jump at transition boundaries.

### Testing
- Built the project with `./gradlew build` which completed successfully.
- Compiled the HMG renderer with `./gradlew :HMG:compileJava` which succeeded with no compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116fe123348329bdce5202e8d4be25)