### PR TITLE
Smooth ADS/Sprint/Reload transitions and fix ADS position jump

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
@@ -47,6 +47,10 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 	public static boolean prevSprintState = false;
 	public static boolean firstPerson_ADSState = false;
 	public static boolean prevADSState = false;
+	private static float adsTransition = 0.0F;
+	private static float sprintTransition = 0.0F;
+	private static float reloadTransition = 0.0F;
+	private static long adsTransitionLastNanos = 0L;
 	public static boolean firstPerson_ReloadState = false;
 	public static boolean prevReloadState = false;
 	private static FloatBuffer colorBuffer = GLAllocation.createDirectFloatBuffer(16);
@@ -627,29 +631,29 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 					//boolean isreloading = this.getbooleanfromnbt("IsReloading");
 					//ununused?
+					updateADSProgress(firstPerson_ADSState, firstPerson_SprintState, firstPerson_ReloadState);
+					float adsBlend = getADSBlend(adsTransition);
+					float sprintBlend = getADSBlend(sprintTransition);
+					float reloadBlend = getADSBlend(reloadTransition);
 					if (firstPerson_ReloadState)
 					{
-						if (prevReloadState)
+						if (reloadTransition > 0.0F)
 							setUpGunPos_equipe(0);
 						else if (prevSprintState && !nbt.getBoolean("set_up"))
-							setUpGunPos_equipe_sprint(0, 1 - smoothing);
-						else if (prevADSState)
-							setUpGunPos_ADS(-1.4F, 1 - smoothing);
+							setUpGunPos_equipe_sprint(0, 1 - sprintBlend);
+						else if (adsTransition > 0.0F)
+							setUpGunPos_ADS(-1.4F, adsBlend);
 						else
 							setUpGunPos_equipe(0);
 					}
-					else if (firstPerson_ADSState && prevADSState)
+					else if (reloadTransition > 0.0F)
+						setUpGunPos_equipe(0);
+					else if (adsTransition >= 0.999F)
 						setUpGunPos_ADS(-1.4F);
-					else if (firstPerson_ADSState)
-						setUpGunPos_ADS(-1.4F, smoothing);
-					else if (prevADSState)
-						setUpGunPos_ADS(-1.4F, 1 - smoothing);
-					else if (firstPerson_SprintState && prevSprintState && !nbt.getBoolean("set_up"))
-						setUpGunPos_equipe_sprint(0, 1);
-					else if (firstPerson_SprintState && !nbt.getBoolean("set_up"))
-						setUpGunPos_equipe_sprint(0, smoothing);
-					else if (prevSprintState && !nbt.getBoolean("set_up"))
-						setUpGunPos_equipe_sprint(0, 1 - smoothing);
+					else if (adsTransition > 0.0F)
+						setUpGunPos_ADS(-1.4F, adsBlend);
+					else if (sprintTransition > 0.0F && !nbt.getBoolean("set_up"))
+						setUpGunPos_equipe_sprint(0, sprintBlend);
 					else
 						setUpGunPos_equipe(0);
 
@@ -770,7 +774,10 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 	public void setUpGunPos_ADS(float reco,float interPole) {
 		GL11.glRotatef(180f, 1.0F, 0.0F, 0.0F);
 		GL11.glRotatef(180f, 0.0F, 0.0F, 1.0F);
-		GL11.glTranslatef(modelPosX * (1 - interPole), modelPosY * (1 - interPole), (modelPosZ) * (1 - interPole));// -0.2F//-0.7,0.7,0
+		// Match the exact hipfire base transform while interpolating into ADS.
+		// Using modelPosZ without the +1.4f hipfire offset causes a small jump at
+		// transition start/end when the gun is resting off-center.
+		GL11.glTranslatef(modelPosX * (1 - interPole), modelPosY * (1 - interPole), (modelPosZ + 1.4f) * (1 - interPole));// -0.2F//-0.7,0.7,0
 
 		if(gunitem != null && nbt != null && gunitem.gunInfo.sightOffset_zeroIn != null && nbt.getInteger("currentElevation") >= 0 && gunitem.gunInfo.sightOffset_zeroIn.length>nbt.getInteger("currentElevation")) {
 			Vector3d sightOffset_zeroIn = gunitem.gunInfo.sightOffset_zeroIn[nbt.getInteger("currentElevation")];
@@ -837,6 +844,38 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 
 	public float getSmoothing(){
 		return smoothing;
+	}
+
+	private static float getADSBlend(float progress){
+		float clamped = MathHelper.clamp_float(progress, 0.0F, 1.0F);
+		return clamped * clamped * (3.0F - 2.0F * clamped);
+	}
+
+	private static void updateADSProgress(boolean adsActive, boolean sprintActive, boolean reloadActive){
+		long now = System.nanoTime();
+		if(adsTransitionLastNanos == 0L){
+			adsTransitionLastNanos = now;
+		}
+		float dt = (now - adsTransitionLastNanos) / 1000000000.0F;
+		adsTransitionLastNanos = now;
+		dt = MathHelper.clamp_float(dt, 0.0F, 0.05F);
+		float durationSec = 0.18F;
+		float step = MathHelper.clamp_float(dt / durationSec, 0.0F, 0.12F);
+		if(adsActive){
+			adsTransition = Math.min(1.0F, adsTransition + step);
+		}else{
+			adsTransition = Math.max(0.0F, adsTransition - step);
+		}
+		if(sprintActive){
+			sprintTransition = Math.min(1.0F, sprintTransition + step);
+		}else{
+			sprintTransition = Math.max(0.0F, sprintTransition - step);
+		}
+		if(reloadActive){
+			reloadTransition = Math.min(1.0F, reloadTransition + step);
+		}else{
+			reloadTransition = Math.max(0.0F, reloadTransition - step);
+		}
 	}
 
 	public void bindPlayertexture(Entity entityplayer) {


### PR DESCRIPTION
### Motivation
- Remove abrupt pops when toggling aiming, sprinting, or reloading by animating the transitions and easing the blends.
- Prevent a small positional jump when entering/exiting ADS by matching the ADS interpolation to the hipfire base transform.

### Description
- Added per-state transition progress variables `adsTransition`, `sprintTransition`, `reloadTransition` and a time-tracking variable `adsTransitionLastNanos` to drive frame-rate independent interpolation.
- Implemented `updateADSProgress(...)` to integrate transition progress each frame with clamped delta-time and a fixed `durationSec` (0.18s), and applied a capped step per-frame.
- Implemented `getADSBlend(...)` using a smoothstep easing (`t*t*(3-2*t)`) and used blends when selecting/interpolating gun pose calls instead of raw boolean checks.
- Adjusted `setUpGunPos_ADS(...)` to include the hipfire Z offset (`modelPosZ + 1.4f`) when interpolating to ADS to remove a visible jump at transition boundaries.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116fe123348329bdce5202e8d4be25)