### PR TITLE
Introduce Overdrive camera system and coremod hooks for client-side camera transforms

### DIFF
--- a/HMG/build.gradle
+++ b/HMG/build.gradle
@@ -139,6 +139,10 @@ processResources {
 jar {
 	baseName = 'HandmadeGunsOverdrive'
 	version = project.version
+	manifest {
+		attributes 'FMLCorePlugin': 'handmadeguns.coremod.HMGOverdriveCorePlugin'
+		attributes 'FMLCorePluginContainsFMLMod': 'true'
+	}
 }
 
 // ===========================

--- a/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
+++ b/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import handmadeguns.client.audio.BulletSoundHMG;
+import handmadeguns.client.camera.OverdriveCameraController;
 import handmadeguns.client.audio.GunSoundHMG;
 import handmadeguns.client.audio.MovingSoundHMG;
 import handmadeguns.client.audio.ReloadSoundHMG;
@@ -199,6 +200,7 @@ public class ClientProxyHMG extends CommonSideProxyHMG {
 		ClientRegistry.registerKeyBinding(Mode.keyBinding);
 		MinecraftForge.EVENT_BUS.register(new HMGParticles());
 		MinecraftForge.EVENT_BUS.register(new HMGFovHandler());
+		OverdriveCameraController.registerForgeEvents();
 
 
 		try {

--- a/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
+++ b/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
@@ -21,6 +21,7 @@ import cpw.mods.fml.common.gameevent.InputEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import handmadeguns.blocks.HMGBlockMounter;
+import handmadeguns.camera.CameraConfig;
 import handmadeguns.command.HMG_CommandReloadparm;
 import handmadeguns.entity.*;
 import handmadeguns.entity.bullets.*;
@@ -231,6 +232,7 @@ public class HandmadeGunsCore {
 		cfg_Flash	= lconf.get("Render", "cfg_Flash", true).getBoolean(true);
 		cfg_defaultknockback = lconf.get("Gun", "cfg_KnockBack", 0.05).getDouble(0.05);
 		cfg_defaultknockbacky = lconf.get("Gun", "cfg_KnockBackY", 0.01).getDouble(0.01);
+		CameraConfig.load(lconf);
 
 		lconf.save();
 
@@ -748,9 +750,11 @@ public class HandmadeGunsCore {
 		FMLCommonHandler.instance().bus().register(hmgLivingUpdateEvent);
 		MinecraftForge.EVENT_BUS.register(hmgLivingUpdateEvent);
 
-		RenderTickSmoothing renderTickSmoothing = new RenderTickSmoothing();
-		FMLCommonHandler.instance().bus().register(renderTickSmoothing);
-		MinecraftForge.EVENT_BUS.register(renderTickSmoothing);
+		if (pEvent.getSide().isClient()) {
+			RenderTickSmoothing renderTickSmoothing = new RenderTickSmoothing();
+			FMLCommonHandler.instance().bus().register(renderTickSmoothing);
+			MinecraftForge.EVENT_BUS.register(renderTickSmoothing);
+		}
 
 		//I don't know if this is needed. I don't know how this fucking mod works. I don't know why this isn't working. OH MY GOD JUST FUCKING WORK
 		//NetworkRegistry.INSTANCE.registerGuiHandler(this, new HMGGuiHandler());

--- a/HMG/src/main/java/handmadeguns/camera/CameraConfig.java
+++ b/HMG/src/main/java/handmadeguns/camera/CameraConfig.java
@@ -1,0 +1,93 @@
+package handmadeguns.camera;
+
+import net.minecraftforge.common.config.Configuration;
+
+/** Client camera-feel configuration. Read on both sides, but consumed only by client event handlers. */
+public final class CameraConfig {
+    private static final String CATEGORY = "ClientCamera";
+
+    public static boolean masterEnabled = true;
+
+    public static boolean rotationSmoothingEnabled = true;
+    public static float smoothingStrength = 0.35F;
+    public static float maxYawOffset = 4.0F;
+    public static float maxPitchOffset = 3.0F;
+
+    public static boolean motionTiltEnabled = true;
+    public static float motionTiltMaxRoll = 4.0F;
+    public static float motionTiltMaxPitchOffset = 2.0F;
+    public static float motionTiltReturnSpeed = 0.18F;
+
+    public static boolean bobEnabled = true;
+    public static float bobStrength = 0.45F;
+    public static float bobSpeed = 0.72F;
+    public static float bobSprintMultiplier = 1.35F;
+    public static float bobAdsMultiplier = 0.45F;
+    public static boolean bobReplaceVanilla = true;
+
+    public static boolean fovEnabled = true;
+    public static float fovLerpSpeed = 0.22F;
+    public static float sprintFovBoost = 0.04F;
+    public static float adsFovSpeed = 0.34F;
+
+    public static boolean shakeEnabled = true;
+    public static float maxShakePitch = 3.5F;
+    public static float maxShakeYaw = 2.0F;
+    public static float maxShakeRoll = 3.0F;
+    public static float recoilShakeMultiplier = 0.18F;
+    public static float explosionShakeMultiplier = 1.0F;
+    public static float landingShakeMultiplier = 1.0F;
+
+    public static boolean hurtEffectEnabled = true;
+    public static boolean hurtReplaceVanilla = false;
+    public static boolean hurtEffectAddsShake = true;
+    public static float hurtEffectStrength = 6.0F;
+    public static float hurtShakeStrength = 0.45F;
+
+    private CameraConfig() {
+    }
+
+    public static void load(Configuration config) {
+        masterEnabled = config.get(CATEGORY, "enabled", masterEnabled,
+                "Master switch for the low-conflict, client-only first-person camera feel system.").getBoolean(masterEnabled);
+
+        rotationSmoothingEnabled = config.get(CATEGORY, "rotationSmoothing.enabled", rotationSmoothingEnabled).getBoolean(rotationSmoothingEnabled);
+        smoothingStrength = (float) config.get(CATEGORY, "rotationSmoothing.smoothingStrength", smoothingStrength,
+                "Higher values follow mouse input faster; lower values add more visual inertia only.").getDouble(smoothingStrength);
+        maxYawOffset = (float) config.get(CATEGORY, "rotationSmoothing.maxYawOffset", maxYawOffset).getDouble(maxYawOffset);
+        maxPitchOffset = (float) config.get(CATEGORY, "rotationSmoothing.maxPitchOffset", maxPitchOffset).getDouble(maxPitchOffset);
+
+        motionTiltEnabled = config.get(CATEGORY, "motionTilt.enabled", motionTiltEnabled).getBoolean(motionTiltEnabled);
+        motionTiltMaxRoll = (float) config.get(CATEGORY, "motionTilt.maxRoll", motionTiltMaxRoll).getDouble(motionTiltMaxRoll);
+        motionTiltMaxPitchOffset = (float) config.get(CATEGORY, "motionTilt.maxPitchOffset", motionTiltMaxPitchOffset).getDouble(motionTiltMaxPitchOffset);
+        motionTiltReturnSpeed = (float) config.get(CATEGORY, "motionTilt.returnSpeed", motionTiltReturnSpeed).getDouble(motionTiltReturnSpeed);
+
+        bobEnabled = config.get(CATEGORY, "bob.enabled", bobEnabled).getBoolean(bobEnabled);
+        bobStrength = (float) config.get(CATEGORY, "bob.bobStrength", bobStrength).getDouble(bobStrength);
+        bobSpeed = (float) config.get(CATEGORY, "bob.bobSpeed", bobSpeed).getDouble(bobSpeed);
+        bobSprintMultiplier = (float) config.get(CATEGORY, "bob.sprintMultiplier", bobSprintMultiplier).getDouble(bobSprintMultiplier);
+        bobAdsMultiplier = (float) config.get(CATEGORY, "bob.adsMultiplier", bobAdsMultiplier).getDouble(bobAdsMultiplier);
+        bobReplaceVanilla = config.get(CATEGORY, "bob.replaceVanilla", bobReplaceVanilla,
+                "If true, the EntityRenderer bobbing hook skips vanilla bob and applies Overdrive's smoother bob. If false, vanilla bob is preserved.").getBoolean(bobReplaceVanilla);
+
+        fovEnabled = config.get(CATEGORY, "fov.enabled", fovEnabled).getBoolean(fovEnabled);
+        fovLerpSpeed = (float) config.get(CATEGORY, "fov.fovLerpSpeed", fovLerpSpeed).getDouble(fovLerpSpeed);
+        sprintFovBoost = (float) config.get(CATEGORY, "fov.sprintFovBoost", sprintFovBoost).getDouble(sprintFovBoost);
+        adsFovSpeed = (float) config.get(CATEGORY, "fov.adsFovSpeed", adsFovSpeed).getDouble(adsFovSpeed);
+
+        shakeEnabled = config.get(CATEGORY, "shake.enabled", shakeEnabled).getBoolean(shakeEnabled);
+        maxShakePitch = (float) config.get(CATEGORY, "shake.maxPitch", maxShakePitch).getDouble(maxShakePitch);
+        maxShakeYaw = (float) config.get(CATEGORY, "shake.maxYaw", maxShakeYaw).getDouble(maxShakeYaw);
+        maxShakeRoll = (float) config.get(CATEGORY, "shake.maxRoll", maxShakeRoll).getDouble(maxShakeRoll);
+        recoilShakeMultiplier = (float) config.get(CATEGORY, "shake.recoilMultiplier", recoilShakeMultiplier).getDouble(recoilShakeMultiplier);
+        explosionShakeMultiplier = (float) config.get(CATEGORY, "shake.explosionMultiplier", explosionShakeMultiplier).getDouble(explosionShakeMultiplier);
+        landingShakeMultiplier = (float) config.get(CATEGORY, "shake.landingMultiplier", landingShakeMultiplier).getDouble(landingShakeMultiplier);
+
+        hurtEffectEnabled = config.get(CATEGORY, "hurt.enabled", hurtEffectEnabled).getBoolean(hurtEffectEnabled);
+        hurtReplaceVanilla = config.get(CATEGORY, "hurt.replaceVanilla", hurtReplaceVanilla,
+                "If true, the EntityRenderer hurt-camera hook skips vanilla hurt tilt. If false, Overdrive adds a small supplemental damage shake and vanilla remains.").getBoolean(hurtReplaceVanilla);
+        hurtEffectAddsShake = config.get(CATEGORY, "hurt.addShake", hurtEffectAddsShake).getBoolean(hurtEffectAddsShake);
+        hurtEffectStrength = (float) config.get(CATEGORY, "hurt.rollStrength", hurtEffectStrength).getDouble(hurtEffectStrength);
+        hurtShakeStrength = (float) config.get(CATEGORY, "hurt.shakeStrength", hurtShakeStrength).getDouble(hurtShakeStrength);
+    }
+}

--- a/HMG/src/main/java/handmadeguns/client/camera/OverdriveCameraController.java
+++ b/HMG/src/main/java/handmadeguns/client/camera/OverdriveCameraController.java
@@ -1,0 +1,327 @@
+package handmadeguns.client.camera;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import handmadeguns.HandmadeGunsCore;
+import handmadeguns.camera.CameraConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.ExplosionEvent;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+@SideOnly(Side.CLIENT)
+public final class OverdriveCameraController {
+    private static final OverdriveCameraController INSTANCE = new OverdriveCameraController();
+    private static final Random RANDOM = new Random();
+
+    private final List<ShakeImpulse> impulses = new ArrayList<ShakeImpulse>();
+    private boolean registered;
+    private boolean initializedRotation;
+    private boolean wasOnGround = true;
+    private float smoothedYaw;
+    private float smoothedPitch;
+    private float yawOffset;
+    private float pitchOffset;
+    private float motionPitch;
+    private float roll;
+    private float bobPhase;
+    private float bobPitch;
+    private float bobRoll;
+    private float bobTranslate;
+    private float shakeYaw;
+    private float shakePitch;
+    private float shakeRoll;
+    private float fovCurrent = -1.0F;
+    private double lastHorizontalSpeed;
+    private double lastMotionY;
+
+    private OverdriveCameraController() {
+    }
+
+    public static void registerForgeEvents() {
+        if (INSTANCE.registered) return;
+        INSTANCE.registered = true;
+        MinecraftForge.EVENT_BUS.register(INSTANCE);
+    }
+
+    public static void update(float partialTicks) {
+        INSTANCE.updateInternal(partialTicks);
+    }
+
+    public static void applyCameraTransforms(float partialTicks) {
+        INSTANCE.applyCameraTransformsInternal(partialTicks);
+    }
+
+    public static boolean applyCustomBobbing(float partialTicks) {
+        return INSTANCE.applyCustomBobbingInternal(partialTicks);
+    }
+
+    public static float modifyFov(float fov, float partialTicks, boolean useFovSetting) {
+        return INSTANCE.modifyFovInternal(fov);
+    }
+
+    public static boolean applyHurtCameraEffect(float partialTicks) {
+        return INSTANCE.applyHurtCameraEffectInternal(partialTicks);
+    }
+
+    public static void addRecoilShake(float strength) {
+        INSTANCE.addImpulse(strength * CameraConfig.recoilShakeMultiplier, 0.72F, -1.0F, 0.35F, 0.45F);
+    }
+
+    public static void addExplosionShake(float strength) {
+        INSTANCE.addImpulse(strength * CameraConfig.explosionShakeMultiplier, 0.86F, 0.7F, 0.8F, 0.9F);
+    }
+
+    public static void addLandingShake(float strength) {
+        INSTANCE.addImpulse(strength * CameraConfig.landingShakeMultiplier, 0.78F, 0.9F, 0.25F, 0.6F);
+    }
+
+    private void updateInternal(float partialTicks) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (!CameraConfig.masterEnabled || mc == null || mc.thePlayer == null || mc.theWorld == null) {
+            resetSoft();
+            return;
+        }
+
+        EntityClientPlayerMP player = mc.thePlayer;
+        updateRotationSmoothing(player, partialTicks);
+        updateMotionTilt(player);
+        updateBob(player);
+        updateShake();
+        updateLandingShake(player);
+    }
+
+    private void updateRotationSmoothing(EntityClientPlayerMP player, float partialTicks) {
+        if (!CameraConfig.rotationSmoothingEnabled) {
+            yawOffset = approach(yawOffset, 0.0F, 0.5F);
+            pitchOffset = approach(pitchOffset, 0.0F, 0.5F);
+            return;
+        }
+
+        float renderYaw = player.prevRotationYaw + wrapDegrees(player.rotationYaw - player.prevRotationYaw) * partialTicks;
+        float renderPitch = player.prevRotationPitch + (player.rotationPitch - player.prevRotationPitch) * partialTicks;
+        if (!initializedRotation) {
+            smoothedYaw = renderYaw;
+            smoothedPitch = renderPitch;
+            initializedRotation = true;
+        }
+
+        float follow = clamp(CameraConfig.smoothingStrength, 0.01F, 1.0F);
+        smoothedYaw += wrapDegrees(renderYaw - smoothedYaw) * follow;
+        smoothedPitch += (renderPitch - smoothedPitch) * follow;
+        yawOffset = clamp(wrapDegrees(smoothedYaw - renderYaw), -CameraConfig.maxYawOffset, CameraConfig.maxYawOffset);
+        pitchOffset = clamp(smoothedPitch - renderPitch, -CameraConfig.maxPitchOffset, CameraConfig.maxPitchOffset);
+    }
+
+    private void updateMotionTilt(EntityClientPlayerMP player) {
+        if (!CameraConfig.motionTiltEnabled) {
+            roll = approach(roll, 0.0F, CameraConfig.motionTiltReturnSpeed);
+            motionPitch = approach(motionPitch, 0.0F, CameraConfig.motionTiltReturnSpeed);
+            return;
+        }
+
+        double horizontalSpeed = Math.sqrt(player.motionX * player.motionX + player.motionZ * player.motionZ);
+        float yawRad = player.rotationYaw * 0.017453292F;
+        double strafe = player.motionX * Math.cos(yawRad) + player.motionZ * Math.sin(yawRad);
+        double accel = horizontalSpeed - lastHorizontalSpeed;
+        lastHorizontalSpeed = horizontalSpeed;
+
+        float targetRoll = clamp((float) (-strafe * 28.0D), -CameraConfig.motionTiltMaxRoll, CameraConfig.motionTiltMaxRoll);
+        float targetPitch = (float) (-(horizontalSpeed * 2.2D) - accel * 18.0D);
+        if (player.isSprinting()) targetPitch -= 0.55F;
+        if (!player.onGround) targetPitch += clamp((float) (-player.motionY * 2.2D), -1.2F, 1.2F);
+        targetPitch = clamp(targetPitch, -CameraConfig.motionTiltMaxPitchOffset, CameraConfig.motionTiltMaxPitchOffset);
+
+        float speed = clamp(CameraConfig.motionTiltReturnSpeed, 0.01F, 1.0F);
+        roll = approach(roll, targetRoll, speed);
+        motionPitch = approach(motionPitch, targetPitch, speed);
+    }
+
+    private void updateBob(EntityClientPlayerMP player) {
+        if (!CameraConfig.bobEnabled) {
+            bobPitch = approach(bobPitch, 0.0F, 0.25F);
+            bobRoll = approach(bobRoll, 0.0F, 0.25F);
+            bobTranslate = approach(bobTranslate, 0.0F, 0.25F);
+            return;
+        }
+
+        double horizontalSpeed = Math.sqrt(player.motionX * player.motionX + player.motionZ * player.motionZ);
+        float movement = clamp((float) horizontalSpeed * 5.5F, 0.0F, 1.0F);
+        float multiplier = player.isSprinting() ? CameraConfig.bobSprintMultiplier : 1.0F;
+        if (HandmadeGunsCore.Key_ADS(player)) multiplier *= CameraConfig.bobAdsMultiplier;
+        bobPhase += CameraConfig.bobSpeed * (0.25F + movement) * multiplier;
+        float strength = CameraConfig.bobStrength * movement * multiplier;
+        bobPitch = approach(bobPitch, (float) Math.sin(bobPhase * 2.0F) * 0.35F * strength, 0.2F);
+        bobRoll = approach(bobRoll, (float) Math.cos(bobPhase) * 0.22F * strength, 0.2F);
+        bobTranslate = approach(bobTranslate, Math.abs((float) Math.sin(bobPhase)) * 0.035F * strength, 0.2F);
+    }
+
+    private void updateShake() {
+        if (!CameraConfig.shakeEnabled) {
+            impulses.clear();
+            shakeYaw = approach(shakeYaw, 0.0F, 0.4F);
+            shakePitch = approach(shakePitch, 0.0F, 0.4F);
+            shakeRoll = approach(shakeRoll, 0.0F, 0.4F);
+            return;
+        }
+
+        float targetYaw = 0.0F;
+        float targetPitch = 0.0F;
+        float targetRoll = 0.0F;
+        Iterator<ShakeImpulse> iterator = impulses.iterator();
+        while (iterator.hasNext()) {
+            ShakeImpulse impulse = iterator.next();
+            targetPitch += impulse.pitch * impulse.life;
+            targetYaw += impulse.yaw * impulse.life;
+            targetRoll += impulse.roll * impulse.life;
+            impulse.life *= impulse.decay;
+            if (impulse.life < 0.015F) iterator.remove();
+        }
+        shakePitch = clamp(targetPitch, -CameraConfig.maxShakePitch, CameraConfig.maxShakePitch);
+        shakeYaw = clamp(targetYaw, -CameraConfig.maxShakeYaw, CameraConfig.maxShakeYaw);
+        shakeRoll = clamp(targetRoll, -CameraConfig.maxShakeRoll, CameraConfig.maxShakeRoll);
+    }
+
+    private void updateLandingShake(EntityClientPlayerMP player) {
+        if (!wasOnGround && player.onGround && lastMotionY < -0.55D) {
+            addLandingShake((float) Math.min(2.4D, (-lastMotionY - 0.45D) * 1.4D));
+        }
+        wasOnGround = player.onGround;
+        lastMotionY = player.motionY;
+    }
+
+    private void applyCameraTransformsInternal(float partialTicks) {
+        if (!CameraConfig.masterEnabled) return;
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc == null || mc.gameSettings == null || mc.gameSettings.thirdPersonView != 0) return;
+
+        float finalYaw = yawOffset + shakeYaw;
+        float finalPitch = pitchOffset + motionPitch + bobPitch + shakePitch;
+        float finalRoll = roll + bobRoll + shakeRoll;
+        finalYaw = clamp(finalYaw, -CameraConfig.maxYawOffset - CameraConfig.maxShakeYaw, CameraConfig.maxYawOffset + CameraConfig.maxShakeYaw);
+        finalPitch = clamp(finalPitch, -CameraConfig.maxPitchOffset - CameraConfig.motionTiltMaxPitchOffset - CameraConfig.maxShakePitch,
+                CameraConfig.maxPitchOffset + CameraConfig.motionTiltMaxPitchOffset + CameraConfig.maxShakePitch);
+        finalRoll = clamp(finalRoll, -CameraConfig.motionTiltMaxRoll - CameraConfig.maxShakeRoll, CameraConfig.motionTiltMaxRoll + CameraConfig.maxShakeRoll);
+
+        GL11.glRotatef(finalRoll, 0.0F, 0.0F, 1.0F);
+        GL11.glRotatef(finalPitch, 1.0F, 0.0F, 0.0F);
+        GL11.glRotatef(finalYaw, 0.0F, 1.0F, 0.0F);
+    }
+
+    private boolean applyCustomBobbingInternal(float partialTicks) {
+        if (!CameraConfig.masterEnabled || !CameraConfig.bobEnabled || !CameraConfig.bobReplaceVanilla) return false;
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc == null || mc.gameSettings == null || mc.gameSettings.thirdPersonView != 0) return false;
+
+        GL11.glTranslatef(0.0F, -bobTranslate, 0.0F);
+        GL11.glRotatef(bobPitch, 1.0F, 0.0F, 0.0F);
+        GL11.glRotatef(bobRoll, 0.0F, 0.0F, 1.0F);
+        return true;
+    }
+
+    private float modifyFovInternal(float fov) {
+        if (!CameraConfig.masterEnabled || !CameraConfig.fovEnabled) {
+            fovCurrent = -1.0F;
+            return fov;
+        }
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityClientPlayerMP player = mc == null ? null : mc.thePlayer;
+        float target = fov;
+        if (player != null && player.isSprinting()) target += CameraConfig.sprintFovBoost * 70.0F;
+        if (fovCurrent < 0.0F) fovCurrent = target;
+        float speed = player != null && HandmadeGunsCore.Key_ADS(player) ? CameraConfig.adsFovSpeed : CameraConfig.fovLerpSpeed;
+        fovCurrent = approach(fovCurrent, target, clamp(speed, 0.01F, 1.0F));
+        return fovCurrent;
+    }
+
+    private boolean applyHurtCameraEffectInternal(float partialTicks) {
+        if (!CameraConfig.masterEnabled || !CameraConfig.hurtEffectEnabled) return false;
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityLivingBase view = mc == null ? null : mc.renderViewEntity;
+        if (view == null || view.hurtTime <= 0) return false;
+
+        float hurt = (float) view.hurtTime - partialTicks;
+        float amount = clamp(hurt / Math.max(1.0F, (float) view.maxHurtTime), 0.0F, 1.0F);
+        float angle = (float) Math.sin(amount * amount * Math.PI) * CameraConfig.hurtEffectStrength;
+        GL11.glRotatef(angle, 0.0F, 0.0F, 1.0F);
+        if (CameraConfig.hurtEffectAddsShake && view.hurtTime == view.maxHurtTime) {
+            addImpulse(CameraConfig.hurtShakeStrength, 0.76F, 0.7F, 0.45F, 0.85F);
+        }
+        return CameraConfig.hurtReplaceVanilla;
+    }
+
+    @SubscribeEvent
+    public void onExplosionDetonate(ExplosionEvent.Detonate event) {
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityClientPlayerMP player = mc == null ? null : mc.thePlayer;
+        World world = event.world;
+        if (player == null || world == null || !world.isRemote) return;
+        double dx = event.explosion.explosionX - player.posX;
+        double dy = event.explosion.explosionY - player.posY;
+        double dz = event.explosion.explosionZ - player.posZ;
+        double dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        double radius = Math.max(4.0D, event.explosion.explosionSize * 5.0D);
+        if (dist <= radius) addExplosionShake((float) ((1.0D - dist / radius) * event.explosion.explosionSize));
+    }
+
+    private void addImpulse(float strength, float decay, float pitchBias, float yawScale, float rollScale) {
+        if (!CameraConfig.masterEnabled || !CameraConfig.shakeEnabled || strength <= 0.0F) return;
+        strength = clamp(strength, 0.0F, 6.0F);
+        impulses.add(new ShakeImpulse(pitchBias * strength,
+                (RANDOM.nextFloat() * 2.0F - 1.0F) * strength * yawScale,
+                (RANDOM.nextFloat() * 2.0F - 1.0F) * strength * rollScale,
+                clamp(decay, 0.1F, 0.98F)));
+    }
+
+    private void resetSoft() {
+        initializedRotation = false;
+        yawOffset = approach(yawOffset, 0.0F, 0.5F);
+        pitchOffset = approach(pitchOffset, 0.0F, 0.5F);
+        motionPitch = approach(motionPitch, 0.0F, 0.5F);
+        roll = approach(roll, 0.0F, 0.5F);
+        bobPitch = approach(bobPitch, 0.0F, 0.5F);
+        bobRoll = approach(bobRoll, 0.0F, 0.5F);
+        shakeYaw = approach(shakeYaw, 0.0F, 0.5F);
+        shakePitch = approach(shakePitch, 0.0F, 0.5F);
+        shakeRoll = approach(shakeRoll, 0.0F, 0.5F);
+    }
+
+    private static float clamp(float value, float min, float max) {
+        return value < min ? min : (value > max ? max : value);
+    }
+
+    private static float approach(float current, float target, float amount) {
+        amount = clamp(amount, 0.0F, 1.0F);
+        return current + (target - current) * amount;
+    }
+
+    private static float wrapDegrees(float value) {
+        while (value >= 180.0F) value -= 360.0F;
+        while (value < -180.0F) value += 360.0F;
+        return value;
+    }
+
+    private static class ShakeImpulse {
+        private final float pitch;
+        private final float yaw;
+        private final float roll;
+        private final float decay;
+        private float life = 1.0F;
+
+        private ShakeImpulse(float pitch, float yaw, float roll, float decay) {
+            this.pitch = pitch;
+            this.yaw = yaw;
+            this.roll = roll;
+            this.decay = decay;
+        }
+    }
+}

--- a/HMG/src/main/java/handmadeguns/coremod/HMGOverdriveCorePlugin.java
+++ b/HMG/src/main/java/handmadeguns/coremod/HMGOverdriveCorePlugin.java
@@ -1,0 +1,33 @@
+package handmadeguns.coremod;
+
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+
+import java.util.Map;
+
+@IFMLLoadingPlugin.MCVersion("1.7.10")
+@IFMLLoadingPlugin.TransformerExclusions({"handmadeguns.coremod"})
+public class HMGOverdriveCorePlugin implements IFMLLoadingPlugin {
+    @Override
+    public String[] getASMTransformerClass() {
+        return new String[] { "handmadeguns.coremod.OverdriveEntityRendererTransformer" };
+    }
+
+    @Override
+    public String getModContainerClass() {
+        return null;
+    }
+
+    @Override
+    public String getSetupClass() {
+        return null;
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {
+    }
+
+    @Override
+    public String getAccessTransformerClass() {
+        return null;
+    }
+}

--- a/HMG/src/main/java/handmadeguns/coremod/OverdriveEntityRendererTransformer.java
+++ b/HMG/src/main/java/handmadeguns/coremod/OverdriveEntityRendererTransformer.java
@@ -1,0 +1,136 @@
+package handmadeguns.coremod;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import java.util.List;
+
+public class OverdriveEntityRendererTransformer implements IClassTransformer, Opcodes {
+    private static final String ENTITY_RENDERER = "net.minecraft.client.renderer.EntityRenderer";
+    private static final String ENTITY_RENDERER_OBF = "blt";
+    private static final String CONTROLLER = "handmadeguns/client/camera/OverdriveCameraController";
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if (basicClass == null) return null;
+        if (!ENTITY_RENDERER.equals(transformedName) && !ENTITY_RENDERER.equals(name) && !ENTITY_RENDERER_OBF.equals(name)) {
+            return basicClass;
+        }
+
+        ClassNode classNode = new ClassNode();
+        ClassReader reader = new ClassReader(basicClass);
+        reader.accept(classNode, 0);
+
+        int patches = 0;
+        List<MethodNode> methods = classNode.methods;
+        for (MethodNode method : methods) {
+            if (isUpdateCameraAndRender(method)) {
+                patches += injectUpdate(method);
+            } else if (isOrientCamera(method)) {
+                patches += injectOrient(method);
+            } else if (isApplyBobbing(method)) {
+                patches += injectApplyBobbing(method);
+            } else if (isGetFovModifier(method)) {
+                patches += injectFov(method);
+            } else if (isHurtCameraEffect(method)) {
+                patches += injectHurt(method);
+            }
+        }
+
+        if (patches == 0) return basicClass;
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        classNode.accept(writer);
+        return writer.toByteArray();
+    }
+
+    private boolean isUpdateCameraAndRender(MethodNode method) {
+        return "(F)V".equals(method.desc) && ("updateCameraAndRender".equals(method.name) || "func_78480_b".equals(method.name));
+    }
+
+    private boolean isOrientCamera(MethodNode method) {
+        return "(F)V".equals(method.desc) && ("orientCamera".equals(method.name) || "func_78467_g".equals(method.name));
+    }
+
+    private boolean isApplyBobbing(MethodNode method) {
+        return "(F)V".equals(method.desc) && ("applyBobbing".equals(method.name) || "setupViewBobbing".equals(method.name) || "func_78475_f".equals(method.name));
+    }
+
+    private boolean isGetFovModifier(MethodNode method) {
+        return "(FZ)F".equals(method.desc) && ("getFOVModifier".equals(method.name) || "func_78481_a".equals(method.name));
+    }
+
+    private boolean isHurtCameraEffect(MethodNode method) {
+        return "(F)V".equals(method.desc) && ("hurtCameraEffect".equals(method.name) || "func_78482_e".equals(method.name));
+    }
+
+    private int injectUpdate(MethodNode method) {
+        InsnList hook = new InsnList();
+        hook.add(new VarInsnNode(FLOAD, 1));
+        hook.add(new MethodInsnNode(INVOKESTATIC, CONTROLLER, "update", "(F)V"));
+        method.instructions.insert(hook);
+        return 1;
+    }
+
+    private int injectOrient(MethodNode method) {
+        int count = 0;
+        for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
+            if (insn.getOpcode() == RETURN) {
+                InsnList hook = new InsnList();
+                hook.add(new VarInsnNode(FLOAD, 1));
+                hook.add(new MethodInsnNode(INVOKESTATIC, CONTROLLER, "applyCameraTransforms", "(F)V"));
+                method.instructions.insertBefore(insn, hook);
+                count++;
+            }
+        }
+        return count > 0 ? 1 : 0;
+    }
+
+    private int injectApplyBobbing(MethodNode method) {
+        LabelNode vanilla = new LabelNode();
+        InsnList hook = new InsnList();
+        hook.add(new VarInsnNode(FLOAD, 1));
+        hook.add(new MethodInsnNode(INVOKESTATIC, CONTROLLER, "applyCustomBobbing", "(F)Z"));
+        hook.add(new JumpInsnNode(IFEQ, vanilla));
+        hook.add(new org.objectweb.asm.tree.InsnNode(RETURN));
+        hook.add(vanilla);
+        method.instructions.insert(hook);
+        return 1;
+    }
+
+    private int injectFov(MethodNode method) {
+        int count = 0;
+        for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
+            if (insn.getOpcode() == FRETURN) {
+                InsnList hook = new InsnList();
+                hook.add(new VarInsnNode(FLOAD, 1));
+                hook.add(new VarInsnNode(ILOAD, 2));
+                hook.add(new MethodInsnNode(INVOKESTATIC, CONTROLLER, "modifyFov", "(FFZ)F"));
+                method.instructions.insertBefore(insn, hook);
+                count++;
+            }
+        }
+        return count > 0 ? 1 : 0;
+    }
+
+    private int injectHurt(MethodNode method) {
+        LabelNode vanilla = new LabelNode();
+        InsnList hook = new InsnList();
+        hook.add(new VarInsnNode(FLOAD, 1));
+        hook.add(new MethodInsnNode(INVOKESTATIC, CONTROLLER, "applyHurtCameraEffect", "(F)Z"));
+        hook.add(new JumpInsnNode(IFEQ, vanilla));
+        hook.add(new org.objectweb.asm.tree.InsnNode(RETURN));
+        hook.add(vanilla);
+        method.instructions.insert(hook);
+        return 1;
+    }
+}

--- a/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
+++ b/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import handmadeguns.HandmadeGunsCore;
+import handmadeguns.client.camera.OverdriveCameraController;
 import handmadeguns.entity.HMGEntityParticles;
 import handmadeguns.client.render.HMGRenderItemGun_U;
 import handmadeguns.client.render.HMGRenderItemGun_U_NEW;
@@ -60,10 +61,9 @@ public class RenderTickSmoothing {
 
 	public static void addSmoothRecoil(float recoilPitchAmount)
 	{
-		float horizontalSign = RECOIL_RANDOM.nextBoolean() ? 1.0f : -1.0f;
-		float recoilYawAmount = recoilPitchAmount * HORIZONTAL_RECOIL_RATIO * horizontalSign;
-		pendingRecoilPitch += recoilPitchAmount;
-		pendingRecoilYaw += recoilYawAmount;
+		// Visual-only camera impulse. Actual player aim/recoil mechanics are intentionally not changed here;
+		// OverdriveCameraController applies the feel through the patched EntityRenderer render path.
+		OverdriveCameraController.addRecoilShake(Math.abs(recoilPitchAmount));
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
@@ -200,7 +200,7 @@ public class RenderTickSmoothing {
 
 		if (HMG_proxy.getEntityPlayerInstance() == null) return;
 		EntityPlayer entityPlayer = HMG_proxy.getEntityPlayerInstance();
-		applySmoothRecoil(entityPlayer);
+		// Recoil camera feel is now handled visually by OverdriveCameraController; do not write player.rotationYaw/Pitch here.
 
 		ItemStack held = entityPlayer.getCurrentEquippedItem();
 
@@ -313,34 +313,9 @@ public class RenderTickSmoothing {
 
 	private void applySmoothRecoil(EntityPlayer entityPlayer)
 	{
-		if (entityPlayer == null) return;
-		if (pendingRecoilPitch == 0.0f && recoilVelocityPitch == 0.0f
-				&& pendingRecoilYaw == 0.0f && recoilVelocityYaw == 0.0f) return;
-
-		float immediatePitch = pendingRecoilPitch * RECOIL_INITIAL_IMPULSE;
-		float immediateYaw = pendingRecoilYaw * RECOIL_INITIAL_IMPULSE;
-		float delayedPitch = pendingRecoilPitch - immediatePitch;
-		float delayedYaw = pendingRecoilYaw - immediateYaw;
-
-		recoilVelocityPitch += delayedPitch;
-		recoilVelocityYaw += delayedYaw;
-		pendingRecoilPitch = 0.0f;
-		pendingRecoilYaw = 0.0f;
-
-		float recoilStepPitch = immediatePitch + recoilVelocityPitch * RECOIL_SPRING;
-		float recoilStepYaw = immediateYaw + recoilVelocityYaw * RECOIL_SPRING;
-		recoilVelocityPitch *= RECOIL_DAMPING;
-		recoilVelocityYaw *= RECOIL_DAMPING;
-
-		if (Math.abs(recoilVelocityPitch) < 0.001f) {
-			recoilVelocityPitch = 0.0f;
-		}
-		if (Math.abs(recoilVelocityYaw) < 0.001f) {
-			recoilVelocityYaw = 0.0f;
-		}
-
-		entityPlayer.rotationPitch -= recoilStepPitch;
-		entityPlayer.rotationYaw += recoilStepYaw;
+		// Stub retained for binary/source compatibility with older call sites. Forge 1.7.10 camera
+		// events give us a safe client-only render hook, so this method intentionally avoids
+		// mutating entityPlayer.rotationYaw or rotationPitch.
 	}
 
 


### PR DESCRIPTION
### Motivation

- Provide a low-conflict, client-only first-person camera feel (rotation smoothing, motion tilt, bobbing, FOV lerp, shake/hurt/explosion/landing effects and visual recoil) without mutating authoritative player aim state on tick.
- Patch `EntityRenderer` at load time so the visual-only camera system can hook into render lifecycle points safely on vanilla/obfuscated names.

### Description

- Add `handmadeguns.camera.CameraConfig` with client camera configuration and load it from `HandmadeGunsCore` via `CameraConfig.load(lconf)`.
- Implement `handmadeguns.client.camera.OverdriveCameraController` as a client-side controller that provides smoothing, tilt, bobbing, FOV, shake and hurt effects and exposes static hooks (`update`, `applyCameraTransforms`, `applyCustomBobbing`, `modifyFov`, `applyHurtCameraEffect`, `addRecoilShake`, etc.).
- Add a coremod `handmadeguns.coremod.HMGOverdriveCorePlugin` and ASM transformer `OverdriveEntityRendererTransformer` to inject calls into `EntityRenderer` lifecycle methods (`updateCameraAndRender`, `orientCamera`, `applyBobbing`, `getFOVModifier`, `hurtCameraEffect`) for both MCP and obfuscated names.
- Wire the controller into the mod: register Forge events in `ClientProxyHMG`, call `OverdriveCameraController` from `RenderTickSmoothing` (delegate recoil to `addRecoilShake`), and register `RenderTickSmoothing` only on the client side in `HandmadeGunsCore`.
- Update `build.gradle` to add the `FMLCorePlugin` and `FMLCorePluginContainsFMLMod` attributes to the JAR manifest so the coremod is discovered at launch.

### Testing

- Ran `./gradlew build` (project compile and packaging) and the build completed successfully.
- No automated unit tests exist for the new camera code, so no unit test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d18623d608329b2169fa73c2c0644)