### PR TITLE
Separate explosion radius from explosion damage (add configurable explosion damage)

### DIFF
--- a/HMG/src/main/java/handmadeguns/HMGGunMaker.java
+++ b/HMG/src/main/java/handmadeguns/HMGGunMaker.java
@@ -1923,6 +1923,8 @@ public class HMGGunMaker {
 				gunInfo.gravity = parseFloat(type[1]);
 				break;
 			case "Explosion":
+			case "ExplosionRadius":
+			case "explosionradius":
 				gunInfo.ex = parseFloat(type[1]);
 				break;
 			case "BlockDestory":

--- a/HMG/src/main/java/handmadeguns/entity/HMGExplosion.java
+++ b/HMG/src/main/java/handmadeguns/entity/HMGExplosion.java
@@ -23,9 +23,16 @@ import static java.lang.Math.abs;
 public class HMGExplosion extends Explosion {
 	//todo hardpatch for MCH vehicles
 	private static final Random explosionRNG = new Random();
+	private float explosionDamage = -1.0F;
+
 	public HMGExplosion(World p_i1948_1_, Entity p_i1948_2_, double p_i1948_3_, double p_i1948_5_, double p_i1948_7_, float p_i1948_9_) {
+		this(p_i1948_1_, p_i1948_2_, p_i1948_3_, p_i1948_5_, p_i1948_7_, p_i1948_9_, -1.0F);
+	}
+
+	public HMGExplosion(World p_i1948_1_, Entity p_i1948_2_, double p_i1948_3_, double p_i1948_5_, double p_i1948_7_, float p_i1948_9_, float explosionDamage) {
 		super(p_i1948_1_, p_i1948_2_, p_i1948_3_, p_i1948_5_, p_i1948_7_, p_i1948_9_);
 		this.worldObj = p_i1948_1_;
+		this.explosionDamage = explosionDamage;
 	}
 
 	private World worldObj;
@@ -127,7 +134,7 @@ public class HMGExplosion extends Explosion {
 					d7 /= d9;
 					double d10 = (double)this.worldObj.getBlockDensity(vec3, entity.boundingBox);
 					double d11 = (1.0D - d4) * d10;
-					entity.attackEntityFrom(DamageSource.setExplosionSource(this), (float)((int)((d11 * d11 + d11) / 1.2D * (double)this.explosionSize * 3)));
+					entity.attackEntityFrom(DamageSource.setExplosionSource(this), getExplosionDamage(entity, d10, d11, f));
 					//we're gonna be buffing this by a multiple of 3 so mcheli fucks off with it's retarded damg calc
 					//old method:
 					//entity.attackEntityFrom(DamageSource.setExplosionSource(this), (float)((int)((d11 * d11 + d11) / 2.0D * 8.0D * (double)this.explosionSize + 1.0D)));
@@ -153,6 +160,30 @@ public class HMGExplosion extends Explosion {
 		}
 
 		this.explosionSize = f;
+	}
+
+	private float getExplosionDamage(Entity entity, double blockDensity, double vanillaExposure, float fullDamageRadius)
+	{
+		if (this.explosionDamage < 0.0F)
+		{
+			return (float)((int)((vanillaExposure * vanillaExposure + vanillaExposure) / 1.2D * (double)this.explosionSize * 3));
+		}
+
+		double distance = entity.getDistance(this.explosionX, this.explosionY, this.explosionZ);
+		double falloff = 1.0D;
+		double falloffRange = (double)this.explosionSize - (double)fullDamageRadius;
+
+		if (falloffRange > 0.0D && distance > (double)fullDamageRadius)
+		{
+			falloff = 1.0D - ((distance - (double)fullDamageRadius) / falloffRange);
+		}
+
+		if (falloff <= 0.0D || blockDensity <= 0.0D)
+		{
+			return 0.0F;
+		}
+
+		return (float)((double)this.explosionDamage * falloff * blockDensity);
 	}
 
 	/**

--- a/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java
+++ b/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletBase.java
@@ -598,14 +598,10 @@ public class HMGEntityBulletBase extends Entity implements IEntityAdditionalSpaw
 
 			List list = worldObj.loadedEntityList;
 
-			double maxDist = damageRange;
+			double fullDamageDist = damageRange;
+			double maxDist = damageRange * 2.0D;
 			double maxDistSq = maxDist * maxDist;
 
-			// Global shrapnel nerf multiplier (TUNE THIS)
-			final double shrapnelMultiplier = 0.15;  // 15% of normal damage
-
-			// Hard safety cap
-			final float maxShrapnelDamage = 8.0F;    // never exceed 8 damage (~4 hearts)
 
 			for (int j = 0; j < list.size(); ++j) {
 
@@ -658,18 +654,18 @@ public class HMGEntityBulletBase extends Entity implements IEntityAdditionalSpaw
 					}
 				}
 
-				// Distance falloff
+				// Full damage inside the configured radius, then linear falloff to zero
+				// over the same distance beyond it.
 				double dist = Math.sqrt(distSq);
-				double falloff = 1.0 - (dist / maxDist); // linear falloff
+				double falloff = 1.0D;
+				if (dist > fullDamageDist) {
+					falloff = 1.0D - ((dist - fullDamageDist) / (maxDist - fullDamageDist));
+				}
 
 				if (falloff <= 0) continue;
 
 				// FINAL DAMAGE CALC
-				float finalDmg = (float)(baseDmg * falloff * shrapnelMultiplier);
-
-				// Cap max damage to avoid insane values
-				if (finalDmg > maxShrapnelDamage)
-					finalDmg = maxShrapnelDamage;
+				float finalDmg = (float)(baseDmg * falloff);
 
 				if (finalDmg <= 0) continue;
 
@@ -765,7 +761,7 @@ public class HMGEntityBulletBase extends Entity implements IEntityAdditionalSpaw
 		//there is FUCKING MORE EXPLOSION CODE HERE JUST INCASE ALL THE OTHER SHIT WASN'T ENOUGH ALREADY!!!
 		noex = true;
 		if(!worldObj.isRemote){
-			HMGExplosion explosion = new HMGExplosion(worldObj,thrower,x,y,z, level);
+			HMGExplosion explosion = new HMGExplosion(worldObj,thrower,x,y,z, level, Bdamege);
 			explosion.isFlaming = false;
 			explosion.isSmoking = candestroy;
 			if (net.minecraftforge.event.ForgeEventFactory.onExplosionStart(worldObj, explosion)) return;

--- a/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletExprode.java
+++ b/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletExprode.java
@@ -19,7 +19,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntityDamageSourceIndirect;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
@@ -147,19 +146,7 @@ public class HMGEntityBulletExprode extends HMGEntityBulletBase implements IEnti
 		if (hasExploded) return;
 
 
-		// damage source representing this bullet
-		DamageSource ds = DamageSource.causeThrownDamage(this, this.thrower);
-
-		System.out.println("on impact in 'Exprode' logic (server)");
-
-		// Apply direct thrown damage first to the hit entity (if present)
-		if (var1.entityHit != null) {
-			// apply direct damage to the hit entity deterministically
-			var1.entityHit.attackEntityFrom(ds, (float)Bdamege);
-		}
-
-		// Then run explosion logic for blocks/visuals, but make sure explosion
-		// does not apply MCH entity damage (we'll disable entity damage inside explode()).
+		// Run explosion logic for blocks, visuals, and radius damage.
 		if (var1.entityHit != null) {
 			if (!noex && !canbounce) {
 				// register hit entity for your later onUpdate handling
@@ -167,7 +154,7 @@ public class HMGEntityBulletExprode extends HMGEntityBulletBase implements IEnti
 				hitobjectposition = var1;
 				noex = true;
 
-				// call your explode that will NOT damage entities (see next section)
+				// Apply the configured explosion radius and BulletPower damage.
 				this.explode(var1.hitVec.xCoord, var1.hitVec.yCoord + 0.125, var1.hitVec.zCoord,
 						this.exlevel, this.canex && cfg_blockdestroy, this.ex);
 				hasExploded = true;

--- a/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletRocket.java
+++ b/HMG/src/main/java/handmadeguns/entity/bullets/HMGEntityBulletRocket.java
@@ -4,16 +4,12 @@ package handmadeguns.entity.bullets;
 import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import handmadeguns.network.PacketSpawnParticle;
 import net.minecraft.entity.Entity;
-import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 import static handmadeguns.HandmadeGunsCore.HMG_proxy;
 
 public class HMGEntityBulletRocket extends HMGEntityBulletExprode implements IEntityAdditionalSpawnData
 {
-	//what the actual fuck is this spaghetti nightmare code
 	public HMGEntityBulletRocket(World worldIn) {
 		super(worldIn);
 	}
@@ -27,64 +23,9 @@ public class HMGEntityBulletRocket extends HMGEntityBulletExprode implements IEn
 
 	@Override
 	public void explode(double x, double y, double z, float level, boolean candestroy, float exl) {
-		System.out.println("explode fired");
-		if (!worldObj.isRemote) {
-			//handle damage in range probably or something idk hopefully this works
-			DamageSource ds1 = DamageSource.causeThrownDamage(this, this.thrower);
-			this.attackEntityFrom(ds1, Bdamege);
-			System.out.println("serverside damage applied");
-			System.out.println("exlevel: " + this.exlevel + " ex:" + this.ex + "exl:" + exl);
-			//so somehow some way, some why, this is 0 for both. Great.
-			// Handle damage to nearby entities
-			//oh my god
-			List<Entity> entities = worldObj.getEntitiesWithinAABBExcludingEntity(this,
-					this.boundingBox.expand(exlevel, exlevel, exlevel)); // IDEALLY based on the actual explosion size
-			//could also be ex
-			//ok this is either ex or exlevel, this mod is so shit I can't tell which one it actually fucking uses in this case
-			//todo expand size to be the actual explosion size value
-
-			for (Entity target : entities) {
-				if (!target.isDead && target.canBeCollidedWith()) {
-					//float distance = (float) this.getDistanceToEntity(target);
-					//dist unused
-					//float damage = this.getDamageBasedOnDistance(distance, level); // Your method (below)
-					//todone get the fucking stupid ass fucking gunpower info or whatever the fuck we were working
-					// with before the big ass error of death happened
-					System.out.println("new explosion bullshit" + Bdamege + "bdamage" + this.thrower);
-					//debug to see what this stupid shit even is
-					System.out.println("exlevel: " + exlevel + " ex:" + ex);
-					//damage = this.whateverthefuck
-					DamageSource ds = DamageSource.causeThrownDamage(this, this.thrower);
-
-					// hopefully does the base damage that the projectile does as opposed to relying on the stupid fucking explosion value
-					target.attackEntityFrom(ds, Bdamege); //todo Bdamege/distance from impact
-					//holy shit this is a nightmare to work with
-				}
-			}
-
-			// removed if statement
-			//if (canex) {
-				worldObj.createExplosion(this, x, y, z, level, candestroy); // handles both visual and terrain
-			//}
-		}
-
+		super.explode(x, y, z, level, candestroy, exl);
 		this.setDead();
 	}
-
-	//private float getDamageBasedOnDistance(float distance, float explosionPower) {
-	//	//float explosionPower is never used
-	//	float maxDamage = (float)this.damage; // dip my balls in texas road house butter
-	//	float falloffStart = 1.5f;
-	//	float falloffEnd = 3.5f;
-//
-	//	if (distance <= falloffStart) return maxDamage;
-	//	if (distance >= falloffEnd) return 0;
-//
-	//	float falloffRange = falloffEnd - falloffStart;
-	//	float scale = 1.0f - ((distance - falloffStart) / falloffRange);
-	//	return maxDamage * scale;
-	//}
-	//DOES NOT WORK, CAUSED A LOT OF CRASHES AND ISSUES
 
 	public HMGEntityBulletRocket(World worldIn, Entity throwerIn, int damege, float bspeed, float bure, float exl, boolean canex) {
 		this(worldIn, throwerIn, damege, bspeed, bure);

--- a/HMG/src/main/java/handmadeguns/items/guns/HMGItem_Unified_Guns.java
+++ b/HMG/src/main/java/handmadeguns/items/guns/HMGItem_Unified_Guns.java
@@ -102,9 +102,9 @@ public class HMGItem_Unified_Guns extends Item {
 			par3List.add(EnumChatFormatting.WHITE + "Bullet Spread " + "+" + StatCollector.translateToLocal(bure));
 			par3List.add(EnumChatFormatting.WHITE + "Recoil " + "+" + StatCollector.translateToLocal(recoil));
 			par3List.add(EnumChatFormatting.YELLOW + "Reload Time " + "+" + StatCollector.translateToLocal(retime));
-			//todone: explosion radius and lethal radius for explosives, also RPM
+			// Show explosive radius separately from BulletPower damage.
 			if (gunInfo.ex > 0.0f) {
-				par3List.add(EnumChatFormatting.RED + "Explosion " + "+" + StatCollector.translateToLocal(exp));
+				par3List.add(EnumChatFormatting.RED + "Explosion Radius " + "+" + StatCollector.translateToLocal(exp));
 			}
 			if (gunInfo.damagerange > 0.0f) { //I guess this works as a non null check too idk im sure it's fine
 				par3List.add(EnumChatFormatting.RED + "Damage Range " + "+" + StatCollector.translateToLocal(damagerange));


### PR DESCRIPTION
### Motivation
- Allow explosive weapons to specify both a blast radius and an independent damage value so that an `Explosion` (radius) and `BulletPower` (lethality) are configurable separately.  
- Make damage full inside the configured radius and fall off smoothly beyond it, and avoid direct-hit double-application of damage for explosive projectiles.  

### Description
- Add an `explosionDamage` field and overloads to `HMGExplosion` plus a new `getExplosionDamage(...)` that returns configured `explosionDamage` (full inside radius, linear falloff beyond) or falls back to the original vanilla formula when unset, and replace the old damage call with `getExplosionDamage(...)`.  
- Pass weapon `BulletPower` (`Bdamege`) into the `HMGExplosion` constructor from `HMGEntityBulletBase.explode(...)` so blast lethality uses the configured weapon damage.  
- Replace the old shrapnel multiplier + hard cap behavior in `HMGEntityBulletBase.setDead()` with a model that applies full `Bdamege` within `damageRange` and linear falloff out to `damageRange * 2.0`.  
- Route explosive direct hits through the shared explosion path by removing the duplicated direct-hit damage in `HMGEntityBulletExprode.onImpact(...)` and simplify `HMGEntityBulletRocket.explode(...)` to call the unified `super.explode(...)`.  
- Accept `ExplosionRadius` / `explosionradius` as aliases for the existing `Explosion` setting in `HMGGunMaker` and update the in-game tooltip to display `Explosion Radius` to clarify the radius-vs-damage split.  

### Testing
- Ran `git diff --check`, which returned no whitespace/patch errors.  
- Attempted to run `./gradlew compileJava` but the wrapper was not executable in the container, so it was not run (wrapper permission issue).  
- Attempted `bash ./gradlew compileJava` and `gradle compileJava` but both builds failed to complete due to external environment issues (Gradle/ForgeGradle downloads blocked by an HTTP proxy `403` and project configuration errors), so no full compile/test was completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d28ee9b208329b77ea16a25bce67a)