### PR TITLE
Optimize HMG pack loading and TXT parsing (caches + timing)

### DIFF
--- a/HMG/src/main/java/handmadeguns/HMGAddAttachment.java
+++ b/HMG/src/main/java/handmadeguns/HMGAddAttachment.java
@@ -14,7 +14,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import static handmadeguns.HandmadeGunsCore.tabshmg;
@@ -105,7 +104,7 @@ public class HMGAddAttachment
 				String str;
 				while((str = br.readLine()) != null){  // 1行ずつ読み込む
 					//System.out.println(str);
-					String[] type = str.split(",");
+					String[] type = HMGGunMaker.splitComma(str);
 
 					int guntype = 0;
 
@@ -260,7 +259,7 @@ public class HMGAddAttachment
 							//}
 							((HMGItemSightBase)newitem).isnightvision = isnightvision;
 
-							if(hud != null)((HMGItemSightBase)newitem).scopetexture = new ResourceLocation("handmadeguns:textures/misc/" + hud);
+							if(hud != null)((HMGItemSightBase)newitem).scopetexture = HMGGunMaker.getCachedResourceLocation("handmadeguns:textures/misc/" + hud);
 							((HMGItemSightBase)newitem).scopeonly = textureOnly;
 							if(Namegun != null){
 								LanguageRegistry.instance().addNameForObject(newitem, "jp_JP", Namegun);
@@ -276,7 +275,7 @@ public class HMGAddAttachment
 									.setTextureName("handmadeguns:"+ texture).setCreativeTab(HandmadeGunsCore.tabhmg);
 							((HMGItemSightBase)newitem).zoomlevel = zoom;
 							((HMGItemSightBase)newitem).isnightvision = isnightvision;
-							if(hud != null)((HMGItemSightBase)newitem).scopetexture = new ResourceLocation("handmadeguns:textures/misc/" + hud);
+							if(hud != null)((HMGItemSightBase)newitem).scopetexture = HMGGunMaker.getCachedResourceLocation("handmadeguns:textures/misc/" + hud);
 							if(Namegun != null){
 								LanguageRegistry.instance().addNameForObject(newitem, "jp_JP", Namegun);
 								LanguageRegistry.instance().addNameForObject(newitem, "en_US", Namegun);
@@ -291,7 +290,7 @@ public class HMGAddAttachment
 									.setTextureName("handmadeguns:"+texture).setCreativeTab(HandmadeGunsCore.tabhmg);
 							((HMGItemSightBase)newitem).zoomlevel = zoom;
 							((HMGItemSightBase)newitem).isnightvision = isnightvision;
-							if(hud != null)((HMGItemSightBase)newitem).scopetexture = new ResourceLocation("handmadeguns:textures/misc/" + hud);
+							if(hud != null)((HMGItemSightBase)newitem).scopetexture = HMGGunMaker.getCachedResourceLocation("handmadeguns:textures/misc/" + hud);
 							if(Namegun != null){
 								LanguageRegistry.instance().addNameForObject(newitem, "jp_JP", Namegun);
 								LanguageRegistry.instance().addNameForObject(newitem, "en_US", Namegun);
@@ -513,11 +512,10 @@ public class HMGAddAttachment
 							try {
 								if (canobj && isClient) {
 //									System.out.println("" + objmodel);
-									IModelCustom attach = AdvancedModelLoader
-											.loadModel(new ResourceLocation("handmadeguns:textures/model/" + objmodel));
+									IModelCustom attach = HMGGunMaker.getCachedModel("handmadeguns:textures/model/" + objmodel);
 									//todo gun skins here
 
-									ResourceLocation attachtexture = new ResourceLocation("handmadeguns:textures/model/" + objtexture);
+									ResourceLocation attachtexture = HMGGunMaker.getCachedResourceLocation("handmadeguns:textures/model/" + objtexture);
 									MinecraftForgeClient.registerItemRenderer(newitem, new HMGRenderItemCustom(attach, attachtexture));
 								}
 							}catch (Exception e){

--- a/HMG/src/main/java/handmadeguns/HMGAddmagazine.java
+++ b/HMG/src/main/java/handmadeguns/HMGAddmagazine.java
@@ -6,7 +6,6 @@ import handmadeguns.items.HMGItemBullet_with_Internal_Bullet;
 import handmadeguns.client.render.HMGRenderItemCustom;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import java.io.*;
@@ -44,7 +43,7 @@ public class HMGAddmagazine {
                 e.printStackTrace();
             }
             while ((str = br.readLine()) != null) {  // 1�s���ǂݍ���
-                String[] data = str.split(",");
+                String[] data = HMGGunMaker.splitComma(str);
                 if(data.length>0){
                     if(data[0].equals("StackSize")){
                         stacksize = Integer.parseInt(data[1]);
@@ -131,9 +130,8 @@ public class HMGAddmagazine {
                         }
                         System.out.println("" + Name);
                         if(canobj && isClient) {
-                            IModelCustom attach = AdvancedModelLoader
-                                    .loadModel(new ResourceLocation("handmadeguns:textures/model/" + objmodel));
-                            ResourceLocation attachtexture = new ResourceLocation("handmadeguns:textures/model/" + objtexture);
+                            IModelCustom attach = HMGGunMaker.getCachedModel("handmadeguns:textures/model/" + objmodel);
+                            ResourceLocation attachtexture = HMGGunMaker.getCachedResourceLocation("handmadeguns:textures/model/" + objtexture);
                             MinecraftForgeClient.registerItemRenderer(newmagazine, new HMGRenderItemCustom(attach, attachtexture));
                         }
                         GameRegistry.registerItem(newmagazine, Name);

--- a/HMG/src/main/java/handmadeguns/HMGGunMaker.java
+++ b/HMG/src/main/java/handmadeguns/HMGGunMaker.java
@@ -6,7 +6,9 @@ import cpw.mods.fml.common.registry.LanguageRegistry;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import handmadeguns.items.*;
 import handmadeguns.items.guns.*;
@@ -41,6 +43,10 @@ public class HMGGunMaker {
 	public static ScriptEngine currentScript;
 	public static FileReader currentScriptFile;
 
+	private static final ScriptEngineManager SCRIPT_ENGINE_MANAGER = new ScriptEngineManager(null);
+	private static final Map<String, ResourceLocation> RESOURCE_LOCATION_CACHE = new HashMap<String, ResourceLocation>();
+	private static final Map<String, IModelCustom> MODEL_CACHE = new HashMap<String, IModelCustom>();
+
 	public static float damageCof = 0;
 	public static float speedCof = 0;
 
@@ -48,6 +54,9 @@ public class HMGGunMaker {
 
 
 	public void load( boolean isClient, File file1) {
+		long loadStartNanos = System.nanoTime();
+		int parsedLines = 0;
+		int modelRegistrations = 0;
 		GunInfo gunInfo = new GunInfo();
 		String  GunName = null;
 		String  displayNamegun = null;
@@ -287,8 +296,9 @@ public class HMGGunMaker {
 
 				String str;
 				while ((str = br.readLine()) != null) { // 1行ずつ読み込む
+					parsedLines++;
 					// System.out.println(str);
-					String[] type = str.split(",");
+					String[] type = splitComma(str);
 					if(!type[0].equals("Recipe1")&& !type[0].equals("Recipe2") && !type[0].equals("Recipe3") && !type[0].equals("addRecipe") && !type[0].equals("addNewRecipe") && !type[0].equals("Magazine")){
 						for(int i=0;i<type.length;i++){
 							type[i] = type[i].trim();
@@ -309,7 +319,7 @@ public class HMGGunMaker {
 									if (str.equals("{")) continue;
 									if (str.equals("}")) break;
 									if (str.isEmpty()) continue;
-									String[] key = str.split(",");
+									String[] key = splitComma(str);
 									reloadanimation.add(parseInt(key[0]), new Float[]{
 													parseFloat(key[1]),
 													
@@ -971,8 +981,9 @@ public class HMGGunMaker {
 									e.printStackTrace();
 								}
 								if (gunInfo.canobj && isClient) {
-									IModelCustom gunobj = AdvancedModelLoader.loadModel(new ResourceLocation("handmadeguns:textures/model/" + objmodel));
-									ResourceLocation guntexture = new ResourceLocation("handmadeguns:textures/model/" + objtexture);
+									IModelCustom gunobj = getCachedModel("handmadeguns:textures/model/" + objmodel);
+									ResourceLocation guntexture = getCachedResourceLocation("handmadeguns:textures/model/" + objtexture);
+									modelRegistrations++;
 									boolean useLegacyInventoryScale = false;
 									if(partslist.isEmpty()) {
 										partslist = createLegacyCompatibleParts(mat22, mat22posx, mat22posy, mat22posz, mat22rotex, mat22rotey, mat22rotez, mat25, mat25posx, mat25posy, mat25posz, mat25rotex, mat25rotey, mat25rotez, mat31posx, mat31posy, mat31posz, mat31rotex, mat31rotey, mat31rotez, mat32posx, mat32posy, mat32posz, mat32rotex, mat32rotey, mat32rotez, remat31, remat3, cockleft, alljump);
@@ -1074,9 +1085,9 @@ public class HMGGunMaker {
 							}
 
 							if (gunInfo.canobj && isClient) {
-								ResourceLocation guntexture = new ResourceLocation("handmadeguns:textures/model/" + objtexture);
-								IModelCustom gunobj = AdvancedModelLoader
-										.loadModel(new ResourceLocation("handmadeguns:textures/model/" + objmodel));
+								ResourceLocation guntexture = getCachedResourceLocation("handmadeguns:textures/model/" + objtexture);
+								IModelCustom gunobj = getCachedModel("handmadeguns:textures/model/" + objmodel);
+								modelRegistrations++;
 								MinecraftForgeClient.registerItemRenderer(newgun, new HMGRenderItemGun_S(gunobj,guntexture,
 										                                                                        gunInfo.modelscale, modelhigh, modelhighr, modelhighs, modelwidthx, modelwidthxr, modelwidthxs, modelwidthz
 										, modelwidthzr, modelwidthzs, rotationx, rotationxr, rotationxs, rotationy, rotationyr, rotationys
@@ -1326,7 +1337,62 @@ public class HMGGunMaker {
 			e.printStackTrace();
 		} catch (IOException e) {
 			e.printStackTrace();
+		} finally {
+			logLoadTiming(file1, parsedLines, modelRegistrations, loadStartNanos);
 		}
+	}
+
+
+	static String[] splitComma(String value) {
+		return splitPreserveStringSplitSemantics(value, ',');
+	}
+
+	static String[] splitColon(String value) {
+		return splitPreserveStringSplitSemantics(value, ':');
+	}
+
+	private static String[] splitPreserveStringSplitSemantics(String value, char delimiter) {
+		// String.split() compiles a regex for these hot TXT parsing paths.  This
+		// helper keeps String.split's default behavior by discarding trailing empty
+		// tokens, preserving legacy pack compatibility while avoiding regex work.
+		ArrayList<String> tokens = new ArrayList<String>();
+		int start = 0;
+		for (int i = 0; i < value.length(); i++) {
+			if (value.charAt(i) == delimiter) {
+				tokens.add(value.substring(start, i));
+				start = i + 1;
+			}
+		}
+		tokens.add(value.substring(start));
+		for (int i = tokens.size() - 1; i > 0 && tokens.get(i).length() == 0; i--) {
+			tokens.remove(i);
+		}
+		return tokens.toArray(new String[tokens.size()]);
+	}
+
+	static ResourceLocation getCachedResourceLocation(String path) {
+		ResourceLocation location = RESOURCE_LOCATION_CACHE.get(path);
+		if (location == null) {
+			location = new ResourceLocation(path);
+			RESOURCE_LOCATION_CACHE.put(path, location);
+		}
+		return location;
+	}
+
+	static IModelCustom getCachedModel(String path) {
+		IModelCustom model = MODEL_CACHE.get(path);
+		if (model == null) {
+			// Gun pack resources are immutable after the pack scan/resource refresh
+			// phase, so the same OBJ can be safely reused by multiple guns/renderers.
+			model = AdvancedModelLoader.loadModel(getCachedResourceLocation(path));
+			MODEL_CACHE.put(path, model);
+		}
+		return model;
+	}
+
+	private static void logLoadTiming(File file, int parsedLines, int modelRegistrations, long startNanos) {
+		long elapsedMs = (System.nanoTime() - startNanos) / 1000000L;
+		System.out.println("[HMG][Timing] gun TXT parse " + file.getName() + " lines=" + parsedLines + " modelRegistrations=" + modelRegistrations + " took " + elapsedMs + " ms");
 	}
 
 	//TODO:INJECTING
@@ -1351,7 +1417,7 @@ public class HMGGunMaker {
 				while ((str = br.readLine()) != null){
 					str_Debug = str;
 					l++;
-					String[] type = str.split(",");
+					String[] type = splitComma(str);
 
 
 					if(type[0] == null){
@@ -1406,7 +1472,7 @@ public class HMGGunMaker {
 							setSlot(8, type, onslot, items, itemstacks);
 							break;
 						case "CRAFTITEM":
-							itemids = type[1].split(":");
+							itemids = splitColon(type[1]);
 							itemlist = new ArrayList<Object>(Arrays.asList(new Object[9]));
 							char[] rf = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'};
 							for(int var0 = 0; var0 < 9; var0++){
@@ -1511,7 +1577,7 @@ public class HMGGunMaker {
 	}
 	public static void setSlot(int index,String[] type, boolean[] onslot ,Item[] items, ItemStack[] itemstacks){
 		if(type[1] != null){
-			String[] itemids = type[1].split(":");
+			String[] itemids = splitColon(type[1]);
 			if(itemids.length == 2){
 				items[index] = GameRegistry.findItem(itemids[0], itemids[1]);
 				itemstacks[index] = null;
@@ -1596,7 +1662,7 @@ public class HMGGunMaker {
 	}
 	private static ScriptEngine doScript(String s)
 	{
-		ScriptEngine se = (new ScriptEngineManager(null)).getEngineByName("js");//引数にnull入れないと20でぬるぽ
+		ScriptEngine se = SCRIPT_ENGINE_MANAGER.getEngineByName("js");//引数にnull入れないと20でぬるぽ
 
 		try
 		{
@@ -2164,7 +2230,7 @@ public class HMGGunMaker {
 			case "MultiMagazine": {
 				gunInfo.magazine = new Item[type.length-1];
 				for(int i = 1;i < type.length;i++){
-					String[] parts = type[i].split(":");
+					String[] parts = splitColon(type[i]);
 					String modId = parts[0];
 					String name = parts[1];
 					gunInfo.magazine[i-1] = GameRegistry.findItem(modId, name);
@@ -2550,7 +2616,7 @@ public class HMGGunMaker {
 
 	private static ScriptEngine doScript(FileReader s)
 	{
-		ScriptEngine se = (new ScriptEngineManager(null)).getEngineByName("js");//引数にnull入れないと20でぬるぽ
+		ScriptEngine se = SCRIPT_ENGINE_MANAGER.getEngineByName("js");//引数にnull入れないと20でぬるぽ
 
 		try
 		{

--- a/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
+++ b/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
@@ -88,6 +88,13 @@ import static handmadeguns.HMGGunMaker.checkBeforeReadfile;
 
 public class HandmadeGunsCore {
 
+	private static final Comparator<File> FILE_NAME_COMPARATOR = new Comparator<File>() {
+		public int compare(File file1, File file2) {
+			return file1.getName().compareTo(file2.getName());
+		}
+	};
+	private static final ScriptEngineManager SCRIPT_ENGINE_MANAGER = new ScriptEngineManager(null);
+
 	//@Mod.Instance
 	//public static HandmadeGunsCore instance2;
 	public static float textureOffsetU;//for textureAnimation
@@ -288,68 +295,66 @@ public class HandmadeGunsCore {
 
 		//TODO:INJECT_FUNCTION
 		File[] packlist = packdir_normal.listFiles();
-		Arrays.sort(packlist, new Comparator<File>() {
-			public int compare(File file1, File file2){
-				return file1.getName().compareTo(file2.getName());
-			}
-		});
-		for (File aPacklist : packlist) {
-			if (aPacklist.isDirectory()) {
-				File[] addscripts = getFileList(aPacklist, "addscripts");
-				if (addscripts != null && addscripts.length > 0) {
-					for (File aScript : addscripts) {
-						System.out.println("debug" + aScript);
-						try {
-							ScriptEngine script = (new ScriptEngineManager(null)).getEngineByName("js");
+		if (packlist != null) {
+			Arrays.sort(packlist, FILE_NAME_COMPARATOR);
+			for (File aPacklist : packlist) {
+				if (aPacklist.isDirectory()) {
+					File[] addscripts = getFileList(aPacklist, "addscripts");
+					if (addscripts != null && addscripts.length > 0) {
+						for (File aScript : addscripts) {
+							System.out.println("debug" + aScript);
 							try {
-								if (script.toString().contains("Nashorn")) {
-									script.eval("load(\"nashorn:mozilla_compat.js\");");
-								}
-								script.eval(new FileReader(aScript));
+								ScriptEngine script = SCRIPT_ENGINE_MANAGER.getEngineByName("js");
 								try {
-									((Invocable) script).invokeFunction("preInit", pEvent);
+									if (script.toString().contains("Nashorn")) {
+										script.eval("load(\"nashorn:mozilla_compat.js\");");
+									}
+									script.eval(new FileReader(aScript));
+									try {
+										((Invocable) script).invokeFunction("preInit", pEvent);
+									} catch (ScriptException e) {
+										e.printStackTrace();
+									} catch (NoSuchMethodException e) {
+										e.printStackTrace();
+									}
+									scripts.add((Invocable) script);
 								} catch (ScriptException e) {
-									e.printStackTrace();
-								} catch (NoSuchMethodException e) {
-									e.printStackTrace();
+									throw new RuntimeException("Script exec error", e);
 								}
-								scripts.add((Invocable) script);
-							} catch (ScriptException e) {
-								throw new RuntimeException("Script exec error", e);
+							} catch (FileNotFoundException e) {
+								e.printStackTrace();
 							}
-						} catch (FileNotFoundException e) {
-							e.printStackTrace();
 						}
 					}
-				}
-				File[] addscripts_2 = getFileList(aPacklist, "scripts");
-				if (addscripts_2 != null && addscripts_2.length > 0) {
-					for (File aScript : addscripts_2) {
-						System.out.println("debug" + aScript);
-						try {
-							ScriptEngine script = (new ScriptEngineManager(null)).getEngineByName("js");
+					File[] addscripts_2 = getFileList(aPacklist, "scripts");
+					if (addscripts_2 != null && addscripts_2.length > 0) {
+						for (File aScript : addscripts_2) {
+							System.out.println("debug" + aScript);
 							try {
-								if (script.toString().contains("Nashorn")) {
-									script.eval("load(\"nashorn:mozilla_compat.js\");");
-								}
-								script.eval(new FileReader(aScript));
+								ScriptEngine script = SCRIPT_ENGINE_MANAGER.getEngineByName("js");
 								try {
-									((Invocable) script).invokeFunction("preInit", pEvent);
+									if (script.toString().contains("Nashorn")) {
+										script.eval("load(\"nashorn:mozilla_compat.js\");");
+									}
+									script.eval(new FileReader(aScript));
+									try {
+										((Invocable) script).invokeFunction("preInit", pEvent);
+									} catch (ScriptException e) {
+										e.printStackTrace();
+									} catch (NoSuchMethodException e) {
+										e.printStackTrace();
+									}
+									scripts.add((Invocable) script);
 								} catch (ScriptException e) {
-									e.printStackTrace();
-								} catch (NoSuchMethodException e) {
-									e.printStackTrace();
+									throw new RuntimeException("Script exec error", e);
 								}
-								scripts.add((Invocable) script);
-							} catch (ScriptException e) {
-								throw new RuntimeException("Script exec error", e);
+							} catch (FileNotFoundException e) {
+								e.printStackTrace();
 							}
-						} catch (FileNotFoundException e) {
-							e.printStackTrace();
 						}
 					}
+					//fileSetup(filelist1[pack], "addbattlepack", "battlepacks");
 				}
-				//fileSetup(filelist1[pack], "addbattlepack", "battlepacks");
 			}
 		}
 		//END
@@ -361,13 +366,11 @@ public class HandmadeGunsCore {
 
 	}
 	public void readPackResource(File packdir,boolean isClient){
+		long startNanos = System.nanoTime();
+		int copiedResources = 0;
 		File[] packlist = packdir.listFiles();
 		if(packlist == null)return;
-		Arrays.sort(packlist, new Comparator<File>() {
-			public int compare(File file1, File file2){
-				return file1.getName().compareTo(file2.getName());
-			}
-		});
+		Arrays.sort(packlist, FILE_NAME_COMPARATOR);
 		for (File apack : packlist) {
 			if (apack.isDirectory()) {
 				String assetsdirstring = apack.getName() + File.separatorChar + "assets" + File.separatorChar + "handmadeguns" + File.separatorChar;
@@ -380,6 +383,7 @@ public class HandmadeGunsCore {
 									"textures" + File.separatorChar + "model" + File.separatorChar + filemodel[ii].getName());
 							try {
 								FileUtils.copyFile(filemodel[ii], directory111);
+								copiedResources++;
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -395,6 +399,7 @@ public class HandmadeGunsCore {
 									"textures" + File.separatorChar + "items" + File.separatorChar + filetexture[ii].getName());
 							try {
 								FileUtils.copyFile(filetexture[ii], directory111);
+								copiedResources++;
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -410,6 +415,7 @@ public class HandmadeGunsCore {
 									"textures" + File.separatorChar + "misc" + File.separatorChar + filesighttexture[ii].getName());
 							try {
 								FileUtils.copyFile(filesighttexture[ii], directory111);
+								copiedResources++;
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -425,6 +431,7 @@ public class HandmadeGunsCore {
 									"sounds" + File.separatorChar + filesound[ii].getName());
 							try {
 								FileUtils.copyFile(filesound[ii], directory111);
+								copiedResources++;
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -436,7 +443,7 @@ public class HandmadeGunsCore {
 			}
 		}
 
-		for (File file : packdir.listFiles())
+		for (File file : packlist)
 		{
 			if (file.isDirectory())
 			{
@@ -463,9 +470,19 @@ public class HandmadeGunsCore {
 		if(isClient){
 			Minecraft.getMinecraft().refreshResources();
 		}
+		System.out.println("[HMG][Timing] config/resource scan " + packdir.getPath() + " packs=" + packlist.length + " copiedResources=" + copiedResources + " took " + ((System.nanoTime() - startNanos) / 1000000L) + " ms");
 	}
 
 	public void readPack(File packdir,boolean isClient){
+		long startNanos = System.nanoTime();
+		long attachmentNanos = 0L;
+		long magazineNanos = 0L;
+		long bulletNanos = 0L;
+		long gunNanos = 0L;
+		int attachmentFiles = 0;
+		int magazineFiles = 0;
+		int bulletFiles = 0;
+		int gunFiles = 0;
 		File[] packlist = packdir.listFiles();
 		if(packlist == null)return;
 		Arrays.sort(packlist, new Comparator<File>() {
@@ -503,7 +520,10 @@ public class HandmadeGunsCore {
 						});
 						for (int ii = 0; ii < fileattach.length; ii++) {
 							if (fileattach[ii].isFile()) {
+								long phaseStart = System.nanoTime();
 								HMGAddAttachment.load(isClient, fileattach[ii]);
+								attachmentNanos += System.nanoTime() - phaseStart;
+								attachmentFiles++;
 							}
 						}
 					}
@@ -518,7 +538,10 @@ public class HandmadeGunsCore {
 						for (int ii = 0; ii < filelistmag.length; ii++) {
 							if (filelistmag[ii].isFile()) {
 								try {
+									long phaseStart = System.nanoTime();
 									HMGAddmagazine.load(isClient, filelistmag[ii]);
+									magazineNanos += System.nanoTime() - phaseStart;
+									magazineFiles++;
 								} catch (ModelFormatException e) {
 									e.printStackTrace();
 								} catch (IOException e) {
@@ -534,7 +557,10 @@ public class HandmadeGunsCore {
 						for (int ii = 0; ii < filebullet.length; ii++) {
 							if (filebullet[ii].isFile()) {
 								try {
+									long phaseStart = System.nanoTime();
 									HMGAddBullets.load(isClient, filebullet[ii]);
+									bulletNanos += System.nanoTime() - phaseStart;
+									bulletFiles++;
 								} catch (ModelFormatException e) {
 									e.printStackTrace();
 								}
@@ -568,7 +594,7 @@ public class HandmadeGunsCore {
 
 							String str;
 							while ((str = br.readLine()) != null) { // 1行ずつ読み込む
-								String[] key = str.split(",");
+								String[] key = HMGGunMaker.splitComma(str);
 								switch (key[0]) {
 									case "damageCof":
 										HMGGunMaker.damageCof = Float.parseFloat(key[1]);
@@ -588,15 +614,17 @@ public class HandmadeGunsCore {
 					}
 					File diregun = new File(apack, "guns");
 					File[] filegun = diregun.listFiles();
-					Arrays.sort(filegun, new Comparator<File>() {
-						public int compare(File file1, File file2) {
-							return file1.getName().compareTo(file2.getName());
-						}
-					});
+					if (filegun == null) {
+						continue;
+					}
+					Arrays.sort(filegun, FILE_NAME_COMPARATOR);
 					for (int ii = 0; ii < filegun.length; ii++) {
 						if (filegun[ii].isFile()) {
 							try {
+								long phaseStart = System.nanoTime();
 								new HMGGunMaker().load(isClient, filegun[ii]);
+								gunNanos += System.nanoTime() - phaseStart;
+								gunFiles++;
 							} catch (ModelFormatException e) {
 								e.printStackTrace();
 							}
@@ -606,6 +634,11 @@ public class HandmadeGunsCore {
 
 			}
 		}
+		System.out.println("[HMG][Timing] attachment registration files=" + attachmentFiles + " took " + (attachmentNanos / 1000000L) + " ms");
+		System.out.println("[HMG][Timing] magazine registration files=" + magazineFiles + " took " + (magazineNanos / 1000000L) + " ms");
+		System.out.println("[HMG][Timing] bullet registration files=" + bulletFiles + " took " + (bulletNanos / 1000000L) + " ms");
+		System.out.println("[HMG][Timing] gun TXT parse/item registration files=" + gunFiles + " took " + (gunNanos / 1000000L) + " ms");
+		System.out.println("[HMG][Timing] pack load " + packdir.getPath() + " packs=" + packlist.length + " took " + ((System.nanoTime() - startNanos) / 1000000L) + " ms");
 	}
 
 	public static void copyFile(File in, File out) throws IOException {
@@ -1029,14 +1062,12 @@ public class HandmadeGunsCore {
 	//Recipe loading
 	public void readPackRecipe(File packdir){
 
+		long startNanos = System.nanoTime();
+		int recipeFiles = 0;
 		File[] packlist = packdir.listFiles();
 		if(packlist == null) return;
 
-		Arrays.sort(packlist, new Comparator<File>() {
-			public int compare(File file1, File file2){
-				return file1.getName().compareTo(file2.getName());
-			}
-		});
+		Arrays.sort(packlist, FILE_NAME_COMPARATOR);
 
 		for (File aPacklist : packlist) {
 			if (aPacklist.isDirectory()) {
@@ -1058,6 +1089,7 @@ public class HandmadeGunsCore {
 						try {
 							HMGGunMaker.addRecipe(recipeFile); // original crafting system
 							GunSmithRecipeRegistry.registerFromFile(recipeFile); // GUI system
+							recipeFiles++;
 							System.out.println("[HMG] Loaded recipe: " + recipeFile.getAbsolutePath());
 
 						} catch (Exception e) {
@@ -1068,6 +1100,7 @@ public class HandmadeGunsCore {
 				}
 			}
 		}
+		System.out.println("[HMG][Timing] recipe registration " + packdir.getPath() + " files=" + recipeFiles + " took " + ((System.nanoTime() - startNanos) / 1000000L) + " ms");
 	}
 
 


### PR DESCRIPTION
### Motivation
- Reduce mod startup time by removing repeated work in the pack/gun loading path and avoid allocating/compiling regex objects during hot TXT parsing. 
- Cache immutable assets (model/resource locations) and the script-engine manager to prevent repeated construction across many guns/attachments/magazines. 
- Make pack scanning and model/renderer registration safer and measurable while preserving all existing external TXT syntax and gameplay behavior. 

### Description
- Added a shared `ScriptEngineManager` and caches for `ResourceLocation` and `IModelCustom` in `HMGGunMaker` and replaced repeated model/texture construction with `getCachedResourceLocation` and `getCachedModel` so the same OBJ/texture is reused. (`HMG/src/main/java/handmadeguns/HMGGunMaker.java`) 
- Replaced hot `String.split(",")`/`split(":")` uses with `splitComma`, `splitColon` and `splitPreserveStringSplitSemantics` helpers that avoid regex allocation while preserving legacy trailing-token behavior; applied to `HMGGunMaker`, `HMGAddAttachment`, and `HMGAddmagazine`. (`HMG/src/main/java/handmadeguns/HMGGunMaker.java`, `HMG/src/main/java/handmadeguns/HMGAddAttachment.java`, `HMG/src/main/java/handmadeguns/HMGAddmagazine.java`) 
- Added lightweight timing/log prints around major load phases (`config/resource scan`, `gun TXT parse`, `item/recipe/attachment/magazine/bullet registration`) and per-file parse counters to help spot slow packs without changing behavior. (`HMG/src/main/java/handmadeguns/HMGGunMaker.java`, `HMG/src/main/java/handmadeguns/HandmadeGunsCore.java`) 
- Made pack scanning more robust and deterministic by reusing a single `FILE_NAME_COMPARATOR`, null-checking `listFiles()` results, and reusing the scanned arrays instead of re-listing directories. (`HMG/src/main/java/handmadeguns/HandmadeGunsCore.java`) 
- Reused the new parsing and resource/model cache calls inside attachment and magazine loaders so they no longer rebuild `ResourceLocation` or reload OBJ models per-file. (`HMG/src/main/java/handmadeguns/HMGAddAttachment.java`, `HMG/src/main/java/handmadeguns/HMGAddmagazine.java`) 
- Preserved behavior: TXT syntax, field meanings, pack layout, registry/ID names, recipes, attachments, ammo, firing, recoil, reload, networking and all gameplay logic were left intact and guarded by the same `isClient` checks where client-only work is necessary. 

### Testing
- Ran `git diff --check` to ensure no whitespace/merge problems; this succeeded. 
- Executed a local parse/syntax check script (`/tmp/hmg_parse_check.sh`) which runs `javac` on affected files to verify local syntax and that no obvious injection errors were introduced; this completed without producing parse-only errors in the modified code. 
- Attempted to build with the Gradle wrapper (`bash gradlew :HMG:compileJava`) but the wrapper failed to download Gradle due to an external network/proxy `HTTP 403` and could not complete, so a full compile/run was blocked by the environment. 
- Attempted `gradle :HMG:compileJava` with the installed Gradle but the environment/ForgeGradle metadata fetch failed due to the same network/proxy restrictions and legacy build configuration, so full build/run validation could not be performed in this environment. 

If you want, I can (a) run additional localized unit/syntax checks, (b) revert any particular change if it looks risky, or (c) produce a short follow-up patch that adds a debug-mode to dump a before/after timing report at runtime so you can compare on an actual client/server startup where Gradle can run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f1cdae988329af9042680c11a477)