### PR TITLE
Add optional manual pickup for dropped HMG guns

### DIFF
--- a/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
+++ b/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
@@ -1,5 +1,7 @@
 package handmadeguns;
 
+import handmadeguns.client.HMGManualGunPickupClientHandler;
+
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -197,6 +199,8 @@ public class ClientProxyHMG extends CommonSideProxyHMG {
 		ClientRegistry.registerKeyBinding(El_Down.keyBinding);
 		ClientRegistry.registerKeyBinding(SeekerOpen_Close.keyBinding);
 		ClientRegistry.registerKeyBinding(Mode.keyBinding);
+		ClientRegistry.registerKeyBinding(HMGManualGunPickupClientHandler.PICKUP_KEY);
+		cpw.mods.fml.common.FMLCommonHandler.instance().bus().register(new HMGManualGunPickupClientHandler());
 		MinecraftForge.EVENT_BUS.register(new HMGParticles());
 		MinecraftForge.EVENT_BUS.register(new HMGFovHandler());
 

--- a/HMG/src/main/java/handmadeguns/HMGPacketHandler.java
+++ b/HMG/src/main/java/handmadeguns/HMGPacketHandler.java
@@ -59,5 +59,7 @@ public class HMGPacketHandler {
                 Side.CLIENT);
         INSTANCE.registerMessage(MessageCatch_SetElevation.class, PacketSetElevation.class, ++id,
                 Side.SERVER);
+        INSTANCE.registerMessage(MessageCatcher_ManualGunPickup.class, PacketManualGunPickup.class, ++id,
+                Side.SERVER);
     }
 }

--- a/HMG/src/main/java/handmadeguns/Handler/MessageCatcher_ManualGunPickup.java
+++ b/HMG/src/main/java/handmadeguns/Handler/MessageCatcher_ManualGunPickup.java
@@ -1,0 +1,28 @@
+package handmadeguns.Handler;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import handmadeguns.network.PacketManualGunPickup;
+import handmadeguns.util.HMGManualGunPickup;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import static handmadeguns.HandmadeGunsCore.enableManualGunPickup;
+
+public class MessageCatcher_ManualGunPickup implements IMessageHandler<PacketManualGunPickup, IMessage> {
+    @Override
+    public IMessage onMessage(PacketManualGunPickup message, MessageContext ctx) {
+        if (!enableManualGunPickup || ctx == null || ctx.getServerHandler() == null) return null;
+
+        EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+        if (player == null || player.worldObj == null || player.isDead) return null;
+
+        Entity entity = player.worldObj.getEntityByID(message.entityId);
+        if (!(entity instanceof EntityItem)) return null;
+
+        HMGManualGunPickup.pickup(player, (EntityItem) entity);
+        return null;
+    }
+}

--- a/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
+++ b/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
@@ -150,6 +150,11 @@ public class HandmadeGunsCore {
 	public static double cfg_defaultknockback;
 	public static double cfg_defaultknockbacky;
 	public static boolean cfgRender_useStencil = true;
+	public static boolean enableManualGunPickup = true;
+	public static double manualGunPickupRange = 3.0D;
+	public static boolean manualGunPickupRequiresLineOfSight = true;
+	public static boolean manualGunPickupOnlyGuns = true;
+	public static boolean enableGunGroundPhysicsRender = false;
 
 
 	public static Item hmg_bullet;
@@ -238,6 +243,11 @@ public class HandmadeGunsCore {
 		cfg_Flash	= lconf.get("Render", "cfg_Flash", true).getBoolean(true);
 		cfg_defaultknockback = lconf.get("Gun", "cfg_KnockBack", 0.05).getDouble(0.05);
 		cfg_defaultknockbacky = lconf.get("Gun", "cfg_KnockBackY", 0.01).getDouble(0.01);
+		enableManualGunPickup = lconf.get("ManualGunPickup", "enableManualGunPickup", true, "When true, dropped HMG gun items are not picked up by walking over them; players must use the Pickup HMG Gun key.").getBoolean(true);
+		manualGunPickupRange = lconf.get("ManualGunPickup", "manualGunPickupRange", 3.0D, "Maximum distance, in blocks, for the manual dropped-gun pickup request.", 0.1D, 8.0D).getDouble(3.0D);
+		manualGunPickupRequiresLineOfSight = lconf.get("ManualGunPickup", "manualGunPickupRequiresLineOfSight", true, "When true, the server requires the player to be looking at the dropped gun with no block in the way.").getBoolean(true);
+		manualGunPickupOnlyGuns = lconf.get("ManualGunPickup", "manualGunPickupOnlyGuns", true, "When true, only HMG gun items use manual pickup. If false, other HandmadeGuns items may also use it; non-HMG items are never affected.").getBoolean(true);
+		enableGunGroundPhysicsRender = lconf.get("ManualGunPickup", "enableGunGroundPhysicsRender", false, "Client-side only: render dropped HMG guns with a flat, physical-looking orientation when supported by the HMG gun renderer.").getBoolean(false);
 
 		lconf.save();
 
@@ -734,6 +744,7 @@ public class HandmadeGunsCore {
 		WhizEventHandler whizHandler = new WhizEventHandler();
 		FMLCommonHandler.instance().bus().register(whizHandler);
 		MinecraftForge.EVENT_BUS.register(whizHandler);
+		MinecraftForge.EVENT_BUS.register(new HMGManualGunPickupEventHandler());
 
 
 //		EntityRegistry.registerModEntity(EntityItemFrameHMG.class, "ItemFrameHMG", 200, this, 128, 5, true);

--- a/HMG/src/main/java/handmadeguns/client/HMGDroppedGunRenderHelper.java
+++ b/HMG/src/main/java/handmadeguns/client/HMGDroppedGunRenderHelper.java
@@ -1,0 +1,36 @@
+package handmadeguns.client;
+
+import net.minecraft.entity.item.EntityItem;
+import org.lwjgl.opengl.GL11;
+
+import static handmadeguns.HandmadeGunsCore.enableGunGroundPhysicsRender;
+
+public class HMGDroppedGunRenderHelper {
+
+    public static boolean isDroppedEntityRender(Object... data) {
+        if (data == null) return false;
+        for (Object object : data) {
+            if (object instanceof EntityItem) return true;
+        }
+        return false;
+    }
+
+    public static boolean applyGroundTransform(Object... data) {
+        if (!enableGunGroundPhysicsRender || !isDroppedEntityRender(data)) return false;
+
+        EntityItem entityItem = null;
+        for (Object object : data) {
+            if (object instanceof EntityItem) {
+                entityItem = (EntityItem) object;
+                break;
+            }
+        }
+
+        float yaw = entityItem == null ? 0.0F : ((entityItem.getEntityId() * 37) % 360);
+        GL11.glTranslatef(0.0F, -0.08F, 0.0F);
+        GL11.glRotatef(yaw, 0.0F, 1.0F, 0.0F);
+        GL11.glRotatef(90.0F, 0.0F, 0.0F, 1.0F);
+        GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F);
+        return true;
+    }
+}

--- a/HMG/src/main/java/handmadeguns/client/HMGManualGunPickupClientHandler.java
+++ b/HMG/src/main/java/handmadeguns/client/HMGManualGunPickupClientHandler.java
@@ -1,0 +1,35 @@
+package handmadeguns.client;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.InputEvent;
+import handmadeguns.HMGPacketHandler;
+import handmadeguns.network.PacketManualGunPickup;
+import handmadeguns.util.HMGManualGunPickup;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import org.lwjgl.input.Keyboard;
+
+import static handmadeguns.HandmadeGunsCore.enableManualGunPickup;
+import static handmadeguns.HandmadeGunsCore.manualGunPickupRange;
+
+public class HMGManualGunPickupClientHandler {
+    public static final KeyBinding PICKUP_KEY = new KeyBinding("Pickup HMG Gun", Keyboard.KEY_P, "HandmadeGuns");
+
+    @SubscribeEvent
+    public void onKeyInput(InputEvent.KeyInputEvent event) {
+        if (!enableManualGunPickup) return;
+        if (!PICKUP_KEY.isPressed()) return;
+
+        Minecraft minecraft = Minecraft.getMinecraft();
+        if (minecraft == null || minecraft.theWorld == null) return;
+        EntityPlayer player = minecraft.thePlayer;
+        if (player == null || player.isDead) return;
+
+        EntityItem target = HMGManualGunPickup.getLookedAtGunItem(player, Math.max(0.1D, manualGunPickupRange));
+        if (target != null) {
+            HMGPacketHandler.INSTANCE.sendToServer(new PacketManualGunPickup(target.getEntityId()));
+        }
+    }
+}

--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U.java
@@ -1,5 +1,7 @@
 package handmadeguns.client.render;
 
+import handmadeguns.client.HMGDroppedGunRenderHelper;
+
 import cpw.mods.fml.client.FMLClientHandler;
 import handmadeguns.HandmadeGunsCore;
 import handmadeguns.items.*;
@@ -1381,6 +1383,7 @@ public class HMGRenderItemGun_U implements IItemRenderer {
 						glAlphaFunc(GL_EQUAL, 1);
 					}
 					GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+					HMGDroppedGunRenderHelper.applyGroundTransform(data);
 					int cockingtime = nbt.getInteger("CockingTime");
 					boolean recoiled = nbt.getBoolean("Recoiled");
 					int mode = nbt.getInteger("HMGMode");

--- a/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
+++ b/HMG/src/main/java/handmadeguns/client/render/HMGRenderItemGun_U_NEW.java
@@ -1,5 +1,7 @@
 package handmadeguns.client.render;
 
+import handmadeguns.client.HMGDroppedGunRenderHelper;
+
 import handmadeguns.HandmadeGunsCore;
 import handmadeguns.gui.HMGContainerInventoryItem;
 import handmadeguns.items.*;
@@ -697,6 +699,7 @@ public class HMGRenderItemGun_U_NEW implements IItemRenderer {
 				isfirstperson = false;
 				Minecraft.getMinecraft().renderEngine.bindTexture(guntexture);
 				GL11.glPushMatrix();
+				HMGDroppedGunRenderHelper.applyGroundTransform(data);
 				GL11.glScalef(0.4f * scala * gunitem.gunInfo.inworldScale * (isPlacedGun ? gunitem.gunInfo.onTurretScale : 1), 0.4f * scala * gunitem.gunInfo.inworldScale * (isPlacedGun ? gunitem.gunInfo.onTurretScale : 1), 0.4f * scala * gunitem.gunInfo.inworldScale * (isPlacedGun ? gunitem.gunInfo.onTurretScale : 1));
 				rendering_situation(gunstack,null);
 				GL11.glPopMatrix();

--- a/HMG/src/main/java/handmadeguns/event/HMGManualGunPickupEventHandler.java
+++ b/HMG/src/main/java/handmadeguns/event/HMGManualGunPickupEventHandler.java
@@ -1,0 +1,19 @@
+package handmadeguns.event;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import handmadeguns.util.HMGManualGunPickup;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
+
+import static handmadeguns.HandmadeGunsCore.enableManualGunPickup;
+
+public class HMGManualGunPickupEventHandler {
+
+    @SubscribeEvent
+    public void onEntityItemPickup(EntityItemPickupEvent event) {
+        if (!enableManualGunPickup) return;
+        if (event == null || event.item == null) return;
+        if (HMGManualGunPickup.isManualPickupEntity(event.item)) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/HMG/src/main/java/handmadeguns/network/PacketManualGunPickup.java
+++ b/HMG/src/main/java/handmadeguns/network/PacketManualGunPickup.java
@@ -1,0 +1,25 @@
+package handmadeguns.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import io.netty.buffer.ByteBuf;
+
+public class PacketManualGunPickup implements IMessage {
+    public int entityId;
+
+    public PacketManualGunPickup() {
+    }
+
+    public PacketManualGunPickup(int entityId) {
+        this.entityId = entityId;
+    }
+
+    @Override
+    public void toBytes(ByteBuf buffer) {
+        buffer.writeInt(entityId);
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buffer) {
+        entityId = buffer.readInt();
+    }
+}

--- a/HMG/src/main/java/handmadeguns/util/HMGManualGunPickup.java
+++ b/HMG/src/main/java/handmadeguns/util/HMGManualGunPickup.java
@@ -1,0 +1,111 @@
+package handmadeguns.util;
+
+import handmadeguns.items.guns.HMGItem_Unified_Guns;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+
+import java.util.List;
+
+import static handmadeguns.HandmadeGunsCore.manualGunPickupOnlyGuns;
+import static handmadeguns.HandmadeGunsCore.manualGunPickupRange;
+import static handmadeguns.HandmadeGunsCore.manualGunPickupRequiresLineOfSight;
+
+public class HMGManualGunPickup {
+
+    public static boolean isManualPickupStack(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) return false;
+        if (manualGunPickupOnlyGuns) return stack.getItem() instanceof HMGItem_Unified_Guns;
+
+        Item item = stack.getItem();
+        return item instanceof HMGItem_Unified_Guns || item.getClass().getName().startsWith("handmadeguns.");
+    }
+
+    public static boolean isManualPickupEntity(EntityItem entityItem) {
+        return entityItem != null && !entityItem.isDead && isManualPickupStack(entityItem.getEntityItem());
+    }
+
+    public static EntityItem getLookedAtGunItem(EntityPlayer player, double range) {
+        if (player == null || player.worldObj == null) return null;
+        Vec3 start = Vec3.createVectorHelper(player.posX, player.posY + player.getEyeHeight(), player.posZ);
+        Vec3 look = player.getLook(1.0F);
+        Vec3 end = start.addVector(look.xCoord * range, look.yCoord * range, look.zCoord * range);
+
+        AxisAlignedBB search = player.boundingBox.addCoord(look.xCoord * range, look.yCoord * range, look.zCoord * range).expand(1.0D, 1.0D, 1.0D);
+        List list = player.worldObj.getEntitiesWithinAABB(EntityItem.class, search);
+        EntityItem closest = null;
+        double closestDistance = range * range;
+
+        for (Object object : list) {
+            EntityItem entityItem = (EntityItem) object;
+            if (!isManualPickupEntity(entityItem)) continue;
+
+            AxisAlignedBB box = entityItem.boundingBox.expand(0.25D, 0.25D, 0.25D);
+            MovingObjectPosition hit = box.calculateIntercept(start, end);
+            if (hit == null) continue;
+
+            double distance = start.squareDistanceTo(hit.hitVec);
+            if (distance < closestDistance) {
+                closest = entityItem;
+                closestDistance = distance;
+            }
+        }
+
+        return closest;
+    }
+
+    public static boolean canServerPickup(EntityPlayer player, EntityItem entityItem) {
+        if (player == null || entityItem == null || player.isDead || entityItem.isDead) return false;
+        if (player.worldObj == null || entityItem.worldObj != player.worldObj) return false;
+        if (!isManualPickupEntity(entityItem)) return false;
+
+        double range = Math.max(0.1D, manualGunPickupRange);
+        double maxDistanceSq = range * range;
+        if (player.getDistanceSqToEntity(entityItem) > maxDistanceSq) return false;
+
+        EntityItem lookedAt = getLookedAtGunItem(player, range);
+        if (lookedAt != entityItem) return false;
+
+        if (manualGunPickupRequiresLineOfSight) {
+            Vec3 start = Vec3.createVectorHelper(player.posX, player.posY + player.getEyeHeight(), player.posZ);
+            Vec3 target = Vec3.createVectorHelper(entityItem.posX, entityItem.posY + entityItem.height * 0.5D, entityItem.posZ);
+            MovingObjectPosition blockHit = player.worldObj.rayTraceBlocks(start, target);
+            if (blockHit != null) return false;
+        }
+
+        return true;
+    }
+
+    public static boolean pickup(EntityPlayer player, EntityItem entityItem) {
+        if (!canServerPickup(player, entityItem)) return false;
+
+        ItemStack entityStack = entityItem.getEntityItem();
+        if (entityStack == null || entityStack.stackSize <= 0) return false;
+
+        ItemStack insertStack = entityStack.copy();
+        int originalSize = insertStack.stackSize;
+        boolean fullyInserted = player.inventory.addItemStackToInventory(insertStack);
+        int remaining = insertStack.stackSize;
+        int pickedUp = originalSize - remaining;
+
+        if (pickedUp <= 0) return false;
+
+        player.inventory.markDirty();
+        entityItem.playSound("random.pop", 0.2F, ((entityItem.worldObj.rand.nextFloat() - entityItem.worldObj.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+        player.onItemPickup(entityItem, pickedUp);
+
+        if (fullyInserted || remaining <= 0) {
+            entityItem.setDead();
+        } else {
+            entityStack.stackSize = remaining;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent automatic pickup of HMG guns and give players an explicit, secure way to pick them up to avoid accidental collection and improve gameplay clarity. 
- Make the feature configurable and safe: default-off compatible behavior where appropriate, client-only keybinding and rendering, and server-side validation to avoid trusting the client. 

### Description
- Added configuration flags and parameters to control the feature: `enableManualGunPickup`, `manualGunPickupRange`, `manualGunPickupRequiresLineOfSight`, `manualGunPickupOnlyGuns`, and `enableGunGroundPhysicsRender`. 
- Implemented automatic pickup cancellation for HMG dropped items via a Forge `EntityItemPickupEvent` handler and a shared pickup utility that identifies HMG gun items by type (`HMGItem_Unified_Guns`) rather than by name. 
- Added a client keybind `Pickup HMG Gun` (default `P`) and a client-side key handler that raytraces looked-at `EntityItem` instances and sends a `PacketManualGunPickup` to the server, and implemented a server message handler that validates entity existence, range, LOS (optional), and item type before performing inventory insertion with normal `addItemStackToInventory` logic. 
- Added an optional client-only ground/physics render helper used by the HMG item renderers to rotate/lay guns flat when `enableGunGroundPhysicsRender` is enabled, and registered the new packet in `HMGPacketHandler` and the client handler only from the client proxy so dedicated servers won't load client classes. 
- Key modified and new files (high level): configuration/hooks in `HandmadeGunsCore`, client registration in `ClientProxyHMG`, network packet `PacketManualGunPickup`, server handler `MessageCatcher_ManualGunPickup`, shared logic `HMGManualGunPickup`, pickup event handler `HMGManualGunPickupEventHandler`, client key handler `HMGManualGunPickupClientHandler`, and a small renderer helper `HMGDroppedGunRenderHelper`; renderers are patched to call the helper when applicable. 

### Testing
- Ran `git diff --check` to ensure no whitespace/merge errors, which succeeded. 
- Attempted to compile `:HMG:compileJava` with the project Gradle wrapper but the wrapper download was blocked by the environment proxy (Gradle wrapper download returned HTTP 403), so build could not be completed in this environment. 
- Attempted `gradle --offline :HMG:compileJava` with the system Gradle but ForgeGradle/legacy configuration caused configuration failures, so a full compile could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f6cee90c8329ae4b3fa086292bbf)