### PR TITLE
Fix MQO CPU data release null crash

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/modelLoader/emb_modelloader/MQO_MetasequoiaObject.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/emb_modelloader/MQO_MetasequoiaObject.java
@@ -145,7 +145,10 @@ public class MQO_MetasequoiaObject implements IModelCustom_HMG
 	{
 		if (!cpuSourceDataReleased)
 		{
-			vertices.clear();
+			if (vertices != null)
+			{
+				vertices.clear();
+			}
 			materials = null;
 			cpuSourceDataReleased = true;
 		}


### PR DESCRIPTION
### Motivation
- A NullPointerException occurred during model setup when `releaseCpuSourceData()` assumed the `vertices` list was non-null after parsing, causing startup to fail when the parser had already nulled the vertex list.

### Description
- Add a null check around clearing `vertices` in `MQO_MetasequoiaObject.releaseCpuSourceData()` so the CPU-side cleanup tolerates models whose loader already set `vertices` to `null`; materials are still released and the cleanup flag is set (file: `HMG/src/main/java/handmadeguns/client/modelLoader/emb_modelloader/MQO_MetasequoiaObject.java`).

### Testing
- Ran `git diff --check` which reported no whitespace issues and succeeded. 
- Attempted `bash ./gradlew compileJava` but the Gradle wrapper download was blocked by an environment proxy (`HTTP/1.1 403 Forbidden`).
- Attempted `gradle compileJava` with the system Gradle which failed due to incompatibility with the legacy project configuration and missing Minecraft version settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a238ac734908329b5e2ba7369d18046)