### PR TITLE
Make HMG stencil handling Angelica friendly

### DIFF
--- a/HMG/src/main/java/handmadeguns/client/render/FrameBuffer.java
+++ b/HMG/src/main/java/handmadeguns/client/render/FrameBuffer.java
@@ -1,7 +1,5 @@
 package handmadeguns.client.render;
 
-import cpw.mods.fml.client.FMLClientHandler;
-import net.minecraft.client.renderer.OpenGlHelper;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.EXTFramebufferObject;
 
@@ -14,6 +12,8 @@ import static org.lwjgl.opengl.EXTFramebufferObject.*;
 import static org.lwjgl.opengl.GL11.*;
 
 public class FrameBuffer{
+	private static final int GL_DEPTH_STENCIL_ATTACHMENT_EXT = 0x821A;
+	private static final int GL_DEPTH24_STENCIL8_EXT = 0x88F0;
 	public static int defaultFBOID = -1;
 	public static int defaultFBO_DepthID = -1;
 	private int listIndex = -1;
@@ -69,15 +69,16 @@ public class FrameBuffer{
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_INT, (java.nio.ByteBuffer)null);
 		glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, texID, 0);
 
-		//StencilBufferとDepthをアタッチ
+		// Attach depth and stencil as one packed attachment. This matches Angelica's
+		// combined depth/stencil handling and avoids treating the same renderbuffer as
+		// two independent attachments.
 		glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, stencilID);
-//		glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH24_STENCIL8, width, height);
-//		glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER_EXT, stencilID);
-
-
-		OpenGlHelper.func_153186_a(OpenGlHelper.field_153199_f, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, width, height);
-		OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, org.lwjgl.opengl.EXTFramebufferObject.GL_DEPTH_ATTACHMENT_EXT, OpenGlHelper.field_153199_f, stencilID);
-		OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, OpenGlHelper.field_153199_f, stencilID);
+		glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH24_STENCIL8_EXT, width, height);
+		glFramebufferRenderbufferEXT(
+				GL_FRAMEBUFFER_EXT,
+				GL_DEPTH_STENCIL_ATTACHMENT_EXT,
+				GL_RENDERBUFFER_EXT,
+				stencilID);
 
 		glClearColor(0.0F, 0.0F, 0.0F, 0.0F);
 		glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);

--- a/HMG/src/main/java/handmadeguns/client/render/PartsRender.java
+++ b/HMG/src/main/java/handmadeguns/client/render/PartsRender.java
@@ -27,23 +27,6 @@ public abstract class PartsRender {
 
 	public void part_Render(HMGGunParts parts, GunState state, float flame, int remainbullets, HMGGunParts_Motion_PosAndRotation OffsetAndRotation){
 		FMLClientHandler.instance().getWorldClient().theProfiler.startSection("partRender");
-//		System.out.println("" + glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_STENCIL_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT));
-
-//		FrameBuffer.defaultFBOID = glGetInteger(GL_FRAMEBUFFER_BINDING_EXT);
-//		FrameBuffer.defaultFBO_DepthID = glGetInteger(GL_RENDERBUFFER_BINDING_EXT);
-//		System.out.println("debug" + FrameBuffer.defaultFBOID);
-
-
-//		if(glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_STENCIL_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT) == 0) {
-//			System.out.println("attach_Stencil to " + glGetInteger(GL_RENDERBUFFER_BINDING_EXT));
-//			System.out.println("attach_Stencil to " + glGetInteger(GL_TEXTURE_BINDING_BUFFER_EXT));
-//			int width = Display.getWidth();
-//			int height = Display.getHeight();
-//			glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, glGetInteger(GL_RENDERBUFFER_BINDING_EXT));
-//			glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH24_STENCIL8, width, height);
-//			OpenGlHelper.func_153186_a(OpenGlHelper.field_153199_f, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, width, height);
-//			glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER_EXT, glGetInteger(GL_RENDERBUFFER_BINDING_EXT));
-//		}
 		if(!parts.initialized){
 			GL11.glColorMask(false,false,false,false);
 			GL11.glDepthMask(true);
@@ -147,30 +130,33 @@ public abstract class PartsRender {
 //		System.out.println("currentFBO " + RenderTickSmoothing.currentFBO);
 				RenderTickSmoothing.currentRenderBuffer = glGetInteger(GL_RENDERBUFFER_BINDING_EXT);
 //		System.out.println("currentRenderBuffer " + RenderTickSmoothing.currentRenderBuffer);
-				RenderTickSmoothing.currentTextureBuffer = glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_DEPTH_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT);;
+				RenderTickSmoothing.currentTextureBuffer = glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_DEPTH_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT);
 //		System.out.println("currentTextureBuffer " + RenderTickSmoothing.currentTextureBuffer);
 				RenderTickSmoothing.currentStencilBufferID = glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_STENCIL_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT);
 //		System.out.println("currentStencilState " + RenderTickSmoothing.currentStencilState);
 
+				boolean stencilAvailable = RenderTickSmoothing.ensureStencilBufferAvailable();
 				FMLClientHandler.instance().getClient().getTextureManager().bindTexture(this.texture);
 				GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-				GL11.glClear(GL_STENCIL_BUFFER_BIT);
-				GL11.glEnable(GL_STENCIL_TEST);
-				GL11.glStencilMask(1);
-				GL11.glStencilFunc(GL_ALWAYS, 1, -1);
-				GL11.glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
-				GL11.glColorMask(false, false, false, false);
 				GL11.glEnable(GL_BLEND);
 				GL11.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 				GL11.glDepthMask(false);
 				GL11.glAlphaFunc(GL_GREATER, 0.0F);
+				if (stencilAvailable) {
+					GL11.glClear(GL_STENCIL_BUFFER_BIT);
+					GL11.glEnable(GL_STENCIL_TEST);
+					GL11.glStencilMask(1);
+					GL11.glStencilFunc(GL_ALWAYS, 1, -1);
+					GL11.glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+					GL11.glColorMask(false, false, false, false);
 //				this.model.renderPart(parts.partsname_reticlePlate);
-				parts.currentGroup_reticlePlate.render();
+					parts.currentGroup_reticlePlate.render();
 
 
-				GL11.glColorMask(true, true, true, true);
-				GL11.glStencilFunc(GL_EQUAL, 1, -1);
-				GL11.glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+					GL11.glColorMask(true, true, true, true);
+					GL11.glStencilFunc(GL_EQUAL, 1, -1);
+					GL11.glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+				}
 				GL11.glAlphaFunc(GL_GREATER, 0.0F);
 				GL11.glDepthMask(false);
 				GL11.glDepthFunc(GL_ALWAYS);
@@ -187,7 +173,9 @@ public abstract class PartsRender {
 				GL11.glAlphaFunc(GL_GREATER, 0.0F);
 
 				GL11.glDisable(GL_LIGHTING);
-				GL11.glDisable(GL_STENCIL_TEST);
+				if (stencilAvailable) {
+					GL11.glDisable(GL_STENCIL_TEST);
+				}
 //				GL11.glPopMatrix();
 //				int tex = FBO.end();
 //				OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);

--- a/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
+++ b/HMG/src/main/java/handmadeguns/event/RenderTickSmoothing.java
@@ -9,14 +9,10 @@ import handmadeguns.client.render.HMGRenderItemGun_U;
 import handmadeguns.client.render.HMGRenderItemGun_U_NEW;
 import handmadeguns.items.guns.HMGItem_Unified_Guns;
 import net.minecraft.client.entity.EntityClientPlayerMP;
-import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import org.lwjgl.opengl.Display;
-import org.lwjgl.opengl.EXTFramebufferObject;
 
-import java.nio.FloatBuffer;
 import java.util.Random;
 
 import static handmadeguns.HandmadeGunsCore.HMG_proxy;
@@ -24,10 +20,8 @@ import static handmadeguns.HandmadeGunsCore.cfg_Sneak_ByADSKey;
 import static handmadeguns.client.render.HMGRenderItemGun_U_NEW.*;
 import static handmadeguns.event.HMGEventZoom.currentZoomLevel;
 import static handmadevehicle.HMVehicle.HMV_Proxy;
-import static org.lwjgl.opengl.ARBFramebufferObject.*;
 import static org.lwjgl.opengl.EXTFramebufferObject.*;
 import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.NVPackedDepthStencil.GL_DEPTH_STENCIL_NV;
 
 public class RenderTickSmoothing {
 
@@ -43,6 +37,12 @@ public class RenderTickSmoothing {
 	public static int currentRenderBuffer = -1;
 	public static int currentTextureBuffer = -1;
 	public static int currentStencilBufferID = -1;
+	private static final int GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE_EXT = 0x8CD0;
+	private static final int GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT = 0x8CD1;
+	private static final int GL_DEPTH_STENCIL_ATTACHMENT_EXT = 0x821A;
+	private static final int GL_DEPTH_STENCIL = 0x84F9;
+	private static final int GL_DEPTH24_STENCIL8_EXT = 0x88F0;
+	private static final int GL_DEPTH32F_STENCIL8 = 0x8CAD;
 	private static float pendingRecoilPitch = 0.0f;
 	private static float pendingRecoilYaw = 0.0f;
 	private static float recoilVelocityPitch = 0.0f;
@@ -85,104 +85,8 @@ public class RenderTickSmoothing {
 				}
 				currentZoomLevel = 1;
 
-//				System.out.println("currentFBO " + glGetInteger(GL_FRAMEBUFFER_BINDING_EXT));
-				//StencilBufferとDepthをアタッチ
-//				if(FrameBuffer.defaultFBOID != -1 && glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_STENCIL_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT) == 0) {
-//					int width = Display.getWidth();
-//					int height = Display.getHeight();
-//					int prevFrame = glGetInteger(GL_FRAMEBUFFER_BINDING_EXT);
-//					int prevRenderBuffer = glGetInteger(GL_RENDERBUFFER_BINDING_EXT);
-//					glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, FrameBuffer.defaultFBOID);
-////                        System.out.println("debug" + FMLClientHandler.instance().getClient().getFramebuffer().depthBuffer);
-////					System.out.println("debug" + defaultFBO_DepthID);
-//
-////					glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH24_STENCIL8, width, height);
-////                        glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER_EXT, depthID);
-//
-//					glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, defaultFBO_DepthID);
-//					OpenGlHelper.func_153186_a(OpenGlHelper.field_153199_f, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, width, height);
-//					OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, org.lwjgl.opengl.EXTFramebufferObject.GL_DEPTH_ATTACHMENT_EXT, OpenGlHelper.field_153199_f, defaultFBO_DepthID);
-//					OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, OpenGlHelper.field_153199_f, defaultFBO_DepthID);
-//
-//					prevDefID = FrameBuffer.defaultFBOID;
-//					glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, prevFrame);
-//					glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, prevRenderBuffer);
-//				}
-				if(currentFBO != -1 && currentStencilBufferID == 0) {
-					int width = Display.getWidth();
-					int height = Display.getHeight();
-					int prevFrame = glGetInteger(GL_FRAMEBUFFER_BINDING_EXT);
-					int prevRenderBuffer = glGetInteger(GL_RENDERBUFFER_BINDING_EXT);
-					int prevTexture = glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_DEPTH_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT);
+				ensureStencilBufferAvailable();
 
-					glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, currentFBO);
-					System.out.println("attach_Stencil to " + currentFBO);
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE));
-//					System.out.println("FboInfo " + glGetFramebufferAttachmentParameteri( GL_RENDERBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE));
-//                        System.out.println("debug" + FMLClientHandler.instance().getClient().getFramebuffer().depthBuffer);
-//					System.out.println("debug" + defaultFBO_DepthID);
-
-//					glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH24_STENCIL8, width, height);
-//                        glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER_EXT, depthID);
-
-					if(currentTextureBuffer > 0) {
-						System.out.println("" + currentTextureBuffer);
-						glBindTexture(GL_TEXTURE_2D,currentTextureBuffer);
-						int prevWidth = glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH);
-						int prevHeight = glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT);
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_INTERNAL_FORMAT));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_RED_SIZE));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_GREEN_SIZE));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_BLUE_SIZE));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_ALPHA_SIZE));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_DEPTH_SIZE));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_STENCIL_SIZE));
-//						System.out.println("prevFormat " + glGetRenderbufferParameteri( GL_RENDERBUFFER, GL_RENDERBUFFER_SAMPLES));
-
-						if(width == prevWidth && height == prevHeight) {
-//							System.out.println("prevWidth " + prevHeight);
-//							System.out.println("prevWidth " + prevWidth);
-							glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_STENCIL, prevWidth, prevHeight, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, (FloatBuffer) null);
-							glFramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT_EXT, GL_TEXTURE_2D, currentTextureBuffer, 0);
-							glFramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT_EXT, GL_TEXTURE_2D, currentTextureBuffer, 0);
-						}
-					}
-					int status = EXTFramebufferObject.glCheckFramebufferStatusEXT(GL_FRAMEBUFFER);
-					if (status != GL_FRAMEBUFFER_COMPLETE) {
-						System.out.println("ERROR");
-					}
-
-//					if(currentRenderBuffer > 0) {
-//						System.out.println("" + currentRenderBuffer);
-//						glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, currentRenderBuffer);
-//						OpenGlHelper.func_153186_a(OpenGlHelper.field_153199_f, org.lwjgl.opengl.EXTPackedDepthStencil.GL_DEPTH24_STENCIL8_EXT, width, height);
-//						OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, org.lwjgl.opengl.EXTFramebufferObject.GL_DEPTH_ATTACHMENT_EXT, OpenGlHelper.field_153199_f, currentRenderBuffer);
-//						OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, org.lwjgl.opengl.EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, OpenGlHelper.field_153199_f, currentRenderBuffer);
-//					}
-					if (status != GL_FRAMEBUFFER_COMPLETE) {
-						System.out.println("ERROR");
-					}
-
-					{
-						RenderTickSmoothing.currentStencilBufferID = glGetFramebufferAttachmentParameteriEXT(GL_FRAMEBUFFER_EXT,GL_STENCIL_ATTACHMENT_EXT,GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT);
-					}
-
-					glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, prevFrame);
-					glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, prevRenderBuffer);
-					glBindTexture(GL_TEXTURE_2D,prevTexture);
-
-				}
 			break;
 			case END :
 				if(backUppedMouseSensitivity != -1) {
@@ -193,6 +97,93 @@ public class RenderTickSmoothing {
 	}
 
 	//todo: figure out why some guns decide to continue to be in sprint state while firing
+	/**
+	 * Ensure the framebuffer currently used by HMG reticle rendering has a stencil attachment.
+	 *
+	 * <p>The old path reallocated whatever depth texture happened to be attached as
+	 * {@code GL_DEPTH_STENCIL}. That mirrors the kind of global framebuffer mutation older
+	 * renderer stacks tolerated, but it is unsafe with Angelica/Iris because those renderers track and
+	 * reuse the main depth texture. Angelica's framebuffer code instead treats stencil as part of
+	 * an already-combined depth/stencil attachment and binds that attachment atomically. We follow
+	 * that model here: reuse an existing combined depth-stencil texture when present, otherwise
+	 * leave the framebuffer untouched and let the caller avoid stencil-only rendering.
+	 */
+	public static boolean ensureStencilBufferAvailable()
+	{
+		if (currentFBO == -1) {
+			return false;
+		}
+
+		int previousFramebuffer = glGetInteger(GL_FRAMEBUFFER_BINDING_EXT);
+		int previousTexture = glGetInteger(GL_TEXTURE_BINDING_2D);
+		try {
+			glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, currentFBO);
+
+			int stencilAttachment = getFramebufferAttachmentName(GL_STENCIL_ATTACHMENT_EXT);
+			if (stencilAttachment != 0) {
+				currentStencilBufferID = stencilAttachment;
+				return true;
+			}
+
+			int depthAttachment = getFramebufferAttachmentName(GL_DEPTH_ATTACHMENT_EXT);
+			int depthAttachmentType = glGetFramebufferAttachmentParameteriEXT(
+					GL_FRAMEBUFFER_EXT,
+					GL_DEPTH_ATTACHMENT_EXT,
+					GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE_EXT);
+			if (depthAttachment <= 0 || depthAttachmentType != GL_TEXTURE) {
+				currentStencilBufferID = 0;
+				return false;
+			}
+
+			glBindTexture(GL_TEXTURE_2D, depthAttachment);
+			int internalFormat = glGetTexLevelParameteri(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT);
+			if (!isCombinedDepthStencilFormat(internalFormat)) {
+				currentStencilBufferID = 0;
+				return false;
+			}
+
+			glFramebufferTexture2DEXT(
+					GL_FRAMEBUFFER_EXT,
+					GL_DEPTH_STENCIL_ATTACHMENT_EXT,
+					GL_TEXTURE_2D,
+					depthAttachment,
+					0);
+
+			if (glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT) != GL_FRAMEBUFFER_COMPLETE_EXT) {
+				glFramebufferTexture2DEXT(
+						GL_FRAMEBUFFER_EXT,
+						GL_DEPTH_STENCIL_ATTACHMENT_EXT,
+						GL_TEXTURE_2D,
+						0,
+						0);
+				currentStencilBufferID = 0;
+				return false;
+			}
+
+			currentStencilBufferID = getFramebufferAttachmentName(GL_STENCIL_ATTACHMENT_EXT);
+			return currentStencilBufferID != 0;
+		}
+		finally {
+			glBindTexture(GL_TEXTURE_2D, previousTexture);
+			glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, previousFramebuffer);
+		}
+	}
+
+	private static int getFramebufferAttachmentName(int attachment)
+	{
+		return glGetFramebufferAttachmentParameteriEXT(
+				GL_FRAMEBUFFER_EXT,
+				attachment,
+				GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME_EXT);
+	}
+
+	private static boolean isCombinedDepthStencilFormat(int internalFormat)
+	{
+		return internalFormat == GL_DEPTH_STENCIL
+				|| internalFormat == GL_DEPTH24_STENCIL8_EXT
+				|| internalFormat == GL_DEPTH32F_STENCIL8;
+	}
+
 	@SubscribeEvent
 	public void clientTickEvent(TickEvent.ClientTickEvent event)
 	{


### PR DESCRIPTION
### Motivation
- The HMG code contained logic that reallocated or repurposed the active depth texture (OptiFine-style behavior) to create a stencil attachment, which is unsafe for Angelica/Iris because those renderers manage and reuse main depth textures and expect combined depth/stencil handling.
- The change aims to avoid mutating renderer-owned depth textures and instead adopt an Angelica-compatible approach: reuse combined depth/stencil attachments when present and fall back to stencil-free rendering otherwise.

### Description
- Add `ensureStencilBufferAvailable()` to `RenderTickSmoothing` to safely probe the current framebuffer for a stencil attachment, reuse a combined depth/stencil texture when available, and restore GL bindings afterwards; new GL constants were added to support the checks.
- Make reticle rendering in `PartsRender` conditional: query `ensureStencilBufferAvailable()` and only perform stencil clear/test/write steps when a compatible stencil attachment exists, otherwise render the reticle without mutating the framebuffer.
- Replace the previous per-attachment depth/stencil setup in `FrameBuffer` with a packed depth/stencil renderbuffer attach (`GL_DEPTH24_STENCIL8`) so HMG’s offscreen helper uses a single combined attachment rather than trying to treat depth and stencil separately.
- Remove the old OptiFine-style framebuffer mutations and guard the code paths that previously assumed it was safe to rebind or reallocate the active depth texture.

### Testing
- Ran repository scans (`rg`) to find OptiFine/shader/framebuffer related usages and confirmed the modified locations are the primary sites where HMG touched framebuffer/depth/stencil state; the search completed successfully.
- Performed a local diff and code checks (`git diff --check`) to validate edits; no whitespace/git-diff errors reported.
- Attempted to run a Java compile (`./gradlew :HMG:compileJava` and `gradle :HMG:compileJava`) to validate build-level integration, but compilation was blocked by external network/proxy issues (Gradle wrapper download and ForgeGradle metadata fetch returned HTTP 403), so full build verification could not be completed in this environment.
- Manual runtime behaviour changes were limited to making stencil usage conditional to avoid unsafe framebuffer mutations and therefore should be safe when run under Angelica/Iris; full runtime testing is recommended in an environment where shader/system toolchain (Angelica/Iris) is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a238d96bcf88329bf1eaa7ec880b3ce)