### PR TITLE
Add VBO-backed HMG OBJ model rendering

### DIFF
--- a/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
+++ b/HMG/src/main/java/handmadeguns/ClientProxyHMG.java
@@ -13,6 +13,7 @@ import handmadeguns.client.audio.GunSoundHMG;
 import handmadeguns.client.audio.MovingSoundHMG;
 import handmadeguns.client.audio.ReloadSoundHMG;
 import handmadeguns.client.modelLoader.emb_modelloader.MQO_ModelLoader;
+import handmadeguns.client.modelLoader.obj_modelloaderMod.obj.HMGObjResourceReloadListener;
 import handmadeguns.entity.*;
 import handmadeguns.entity.bullets.*;
 import handmadeguns.event.HMGFovHandler;
@@ -25,6 +26,7 @@ import handmadeguns.tile.TileMounter;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.client.resources.IReloadableResourceManager;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.settings.GameSettings;
@@ -199,6 +201,9 @@ public class ClientProxyHMG extends CommonSideProxyHMG {
 		ClientRegistry.registerKeyBinding(Mode.keyBinding);
 		ClientRegistry.registerKeyBinding(HMGManualGunPickupClientHandler.PICKUP_KEY);
 		cpw.mods.fml.common.FMLCommonHandler.instance().bus().register(new HMGManualGunPickupClientHandler());
+		if (Minecraft.getMinecraft().getResourceManager() instanceof IReloadableResourceManager) {
+			((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager()).registerReloadListener(new HMGObjResourceReloadListener());
+		}
 		MinecraftForge.EVENT_BUS.register(new HMGParticles());
 		MinecraftForge.EVENT_BUS.register(new HMGFovHandler());
 

--- a/HMG/src/main/java/handmadeguns/HMGGunMaker.java
+++ b/HMG/src/main/java/handmadeguns/HMGGunMaker.java
@@ -1379,6 +1379,10 @@ public class HMGGunMaker {
 		return location;
 	}
 
+	public static void clearCachedModels() {
+		MODEL_CACHE.clear();
+	}
+
 	static IModelCustom getCachedModel(String path) {
 		IModelCustom model = MODEL_CACHE.get(path);
 		if (model == null) {

--- a/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
+++ b/HMG/src/main/java/handmadeguns/HandmadeGunsCore.java
@@ -155,6 +155,7 @@ public class HandmadeGunsCore {
 	public static boolean manualGunPickupRequiresLineOfSight = true;
 	public static boolean manualGunPickupOnlyGuns = true;
 	public static boolean enableGunGroundPhysicsRender = false;
+	public static boolean enableVBOModelRendering = true;
 
 
 	public static Item hmg_bullet;
@@ -229,6 +230,7 @@ public class HandmadeGunsCore {
 		// update: this literally has ZERO usages. I don't even know why it's in the mod as a config option.
 		cfg_RenderPlayer	= lconf.get("Render", "cfg_RenderPlayer", false).getBoolean(false);
 		cfgRender_useStencil = lconf.get("Render", "cfg_useStencil", false).getBoolean(false);
+		enableVBOModelRendering = lconf.get("Render", "enableVBOModelRendering", true, "Client-side only: render HMG OBJ model groups from OpenGL VBOs when possible. Disable to force the legacy display-list renderer.").getBoolean(true);
 		cfg_canEjectCartridge	= lconf.get("Cartridge", "cfg_canEjectCartridge", true).getBoolean(true);
 		cfg_Cartridgetime	= lconf.get("Cartridge", "cfg_Cartridgetime", 200).getInt(200);
 		cfg_muzzleflash	= lconf.get("Gun", "cfg_MuzzleFlash", true).getBoolean(true);

--- a/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGGroupObject.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGGroupObject.java
@@ -17,6 +17,8 @@ public class HMGGroupObject
 	public int glDrawingMode;
 	private int displayList = -1;
 	private boolean cpuDataReleased = false;
+	private String modelKey = "unknown";
+	private HMGVboMeshGroup vboMesh;
 
 	public HMGGroupObject()
 	{
@@ -33,6 +35,21 @@ public class HMGGroupObject
         this.name = name;
         this.glDrawingMode = glDrawingMode;
     }
+
+	@SideOnly(Side.CLIENT)
+	public void setModelKey(String modelKey)
+	{
+		this.modelKey = modelKey;
+	}
+
+	@SideOnly(Side.CLIENT)
+	public void releaseVbo()
+	{
+		if (vboMesh != null)
+		{
+			vboMesh.release();
+		}
+	}
 
 	@SideOnly(Side.CLIENT)
     public void initDisplay(){
@@ -65,6 +82,22 @@ public class HMGGroupObject
 	@SideOnly(Side.CLIENT)
     public void render()
     {
+        if (HMGVboModelCache.isEnabled())
+        {
+            if (vboMesh == null)
+            {
+                vboMesh = new HMGVboMeshGroup(modelKey + "#" + name);
+            }
+            // Compilation is intentionally lazy here: render() runs on Minecraft's
+            // client render thread with a current OpenGL context, unlike the OBJ
+            // parser thread used by HMGWavefrontObject(ResourceLocation).
+            if ((vboMesh.isCompiled() || vboMesh.compile(faces, glDrawingMode)) && vboMesh.isCompiled())
+            {
+                vboMesh.render();
+                return;
+            }
+        }
+
         if(displayList == -1)initDisplay();
         else if(displayList != 0) org.lwjgl.opengl.GL11.glCallList(this.displayList);
         else initDisplay();

--- a/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGObjModelLoader.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGObjModelLoader.java
@@ -27,6 +27,19 @@ public class HMGObjModelLoader implements IModelCustomLoader
         return types;
     }
 
+    public static void clearModelCache()
+    {
+        for (IModelCustom model : MODEL_CACHE.values())
+        {
+            if (model instanceof HMGWavefrontObject)
+            {
+                ((HMGWavefrontObject) model).releaseVbos();
+            }
+        }
+        MODEL_CACHE.clear();
+        HMGVboModelCache.releaseAll();
+    }
+
     public static IModelCustom loadHMGModel(ResourceLocation resource) throws ModelFormatException
     {
         if (!resource.getResourcePath().toLowerCase(Locale.ROOT).endsWith(".obj"))

--- a/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGObjResourceReloadListener.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGObjResourceReloadListener.java
@@ -1,0 +1,17 @@
+package handmadeguns.client.modelLoader.obj_modelloaderMod.obj;
+
+import cpw.mods.fml.relauncher.Side;
+import handmadeguns.HMGGunMaker;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+
+/** Clears cached HMG OBJ models and their VBOs when resource packs reload. */
+@SideOnly(Side.CLIENT)
+public class HMGObjResourceReloadListener implements IResourceManagerReloadListener {
+    @Override
+    public void onResourceManagerReload(IResourceManager resourceManager) {
+        HMGGunMaker.clearCachedModels();
+        HMGObjModelLoader.clearModelCache();
+    }
+}

--- a/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGVboMeshGroup.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGVboMeshGroup.java
@@ -1,0 +1,185 @@
+package handmadeguns.client.modelLoader.obj_modelloaderMod.obj;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import handmadeguns.HandmadeGunsCore;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+
+/** VBO representation of one OBJ group/object part. */
+@SideOnly(Side.CLIENT)
+final class HMGVboMeshGroup {
+    private static final int FLOATS_PER_VERTEX = 8;
+    private static final int BYTES_PER_FLOAT = 4;
+    private static final int STRIDE_BYTES = FLOATS_PER_VERTEX * BYTES_PER_FLOAT;
+    private static final long POSITION_OFFSET = 0L;
+    private static final long NORMAL_OFFSET = 3L * BYTES_PER_FLOAT;
+    private static final long UV_OFFSET = 6L * BYTES_PER_FLOAT;
+
+    private final String key;
+    private int bufferId;
+    private int vertexCount;
+    private int glDrawingMode;
+    private boolean compileFailed;
+    private boolean loggedFallback;
+
+    HMGVboMeshGroup(String key) {
+        this.key = key;
+    }
+
+    boolean isCompiled() {
+        return bufferId != 0;
+    }
+
+    boolean hasFailed() {
+        return compileFailed;
+    }
+
+    boolean compile(ArrayList<HMGFace> faces, int drawingMode) {
+        if (compileFailed || bufferId != 0) {
+            return bufferId != 0;
+        }
+        if (faces == null || faces.isEmpty() || drawingMode == -1) {
+            compileFailed = true;
+            logFallback("empty or unknown OBJ group");
+            return false;
+        }
+
+        try {
+            int vertices = 0;
+            for (HMGFace face : faces) {
+                if (face == null || face.vertices == null || face.vertices.length == 0) {
+                    compileFailed = true;
+                    logFallback("invalid face data");
+                    return false;
+                }
+                vertices += face.vertices.length;
+            }
+
+            FloatBuffer data = BufferUtils.createFloatBuffer(vertices * FLOATS_PER_VERTEX);
+            for (HMGFace face : faces) {
+                putFace(data, face);
+            }
+            data.flip();
+
+            bufferId = GL15.glGenBuffers();
+            if (bufferId == 0) {
+                compileFailed = true;
+                logFallback("glGenBuffers returned 0");
+                return false;
+            }
+
+            HMGVboModelCache.bindArrayBuffer(bufferId);
+            GL15.glBufferData(GL15.GL_ARRAY_BUFFER, data, GL15.GL_STATIC_DRAW);
+            HMGVboModelCache.bindArrayBuffer(0);
+
+            vertexCount = vertices;
+            glDrawingMode = drawingMode;
+            HMGVboModelCache.register(this);
+            System.out.println("HandmadeGuns-compiled OBJ VBO group " + key + " (" + vertexCount + " vertices)");
+            return true;
+        } catch (Throwable t) {
+            release();
+            compileFailed = true;
+            logFallback(t.getClass().getSimpleName() + ": " + t.getMessage());
+            return false;
+        }
+    }
+
+    void render() {
+        if (bufferId == 0 || vertexCount <= 0) {
+            return;
+        }
+
+        boolean textureMatrixPushed = false;
+        try {
+            if (HandmadeGunsCore.textureOffsetU != 0.0F || HandmadeGunsCore.textureOffsetV != 0.0F) {
+                GL11.glMatrixMode(GL11.GL_TEXTURE);
+                GL11.glPushMatrix();
+                GL11.glTranslatef(HandmadeGunsCore.textureOffsetU, HandmadeGunsCore.textureOffsetV, 0.0F);
+                GL11.glMatrixMode(GL11.GL_MODELVIEW);
+                textureMatrixPushed = true;
+            }
+
+            HMGVboModelCache.bindArrayBuffer(bufferId);
+            GL11.glEnableClientState(GL11.GL_VERTEX_ARRAY);
+            GL11.glEnableClientState(GL11.GL_NORMAL_ARRAY);
+            GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+            GL11.glVertexPointer(3, GL11.GL_FLOAT, STRIDE_BYTES, POSITION_OFFSET);
+            GL11.glNormalPointer(GL11.GL_FLOAT, STRIDE_BYTES, NORMAL_OFFSET);
+            GL11.glTexCoordPointer(2, GL11.GL_FLOAT, STRIDE_BYTES, UV_OFFSET);
+            GL11.glDrawArrays(glDrawingMode, 0, vertexCount);
+        } finally {
+            HMGVboModelCache.resetClientState();
+            if (textureMatrixPushed) {
+                GL11.glMatrixMode(GL11.GL_TEXTURE);
+                GL11.glPopMatrix();
+                GL11.glMatrixMode(GL11.GL_MODELVIEW);
+            }
+        }
+    }
+
+    boolean release() {
+        if (bufferId == 0) {
+            return false;
+        }
+        try {
+            HMGVboModelCache.deleteBuffer(bufferId);
+        } catch (Throwable ignored) {
+            // Context may already be gone during shutdown.  Forget the id to avoid reusing it.
+        }
+        bufferId = 0;
+        vertexCount = 0;
+        HMGVboModelCache.unregister(this);
+        return true;
+    }
+
+    private void putFace(FloatBuffer data, HMGFace face) {
+        HMGVertex faceNormal = face.faceNormal != null ? face.faceNormal : face.calculateFaceNormal();
+        float averageU = 0.0F;
+        float averageV = 0.0F;
+        boolean hasUv = face.HMGTextureCoordinates != null && face.HMGTextureCoordinates.length > 0;
+
+        if (hasUv) {
+            for (int i = 0; i < face.HMGTextureCoordinates.length; i++) {
+                averageU += face.HMGTextureCoordinates[i].u;
+                averageV += face.HMGTextureCoordinates[i].v;
+            }
+            averageU /= face.HMGTextureCoordinates.length;
+            averageV /= face.HMGTextureCoordinates.length;
+        }
+
+        for (int i = 0; i < face.vertices.length; i++) {
+            HMGVertex vertex = face.vertices[i];
+            HMGVertex normal = faceNormal;
+            if (face.HMGVertexNormals != null && i < face.HMGVertexNormals.length && face.HMGVertexNormals[i] != null) {
+                normal = face.HMGVertexNormals[i];
+            }
+
+            float u = 0.0F;
+            float v = 0.0F;
+            if (hasUv && i < face.HMGTextureCoordinates.length && face.HMGTextureCoordinates[i] != null) {
+                HMGTextureCoordinate tex = face.HMGTextureCoordinates[i];
+                float offsetU = tex.u > averageU ? -0.0005F : 0.0005F;
+                float offsetV = tex.v > averageV ? -0.0005F : 0.0005F;
+                u = tex.u + offsetU;
+                v = tex.v + offsetV;
+            }
+
+            data.put(vertex.x).put(vertex.y).put(vertex.z);
+            data.put(normal.x).put(normal.y).put(normal.z);
+            data.put(u).put(v);
+        }
+    }
+
+    private void logFallback(String reason) {
+        if (!loggedFallback) {
+            System.out.println("HandmadeGuns-OBJ VBO fallback for " + key + ": " + reason);
+            loggedFallback = true;
+        }
+    }
+}

--- a/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGVboModelCache.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGVboModelCache.java
@@ -1,0 +1,100 @@
+package handmadeguns.client.modelLoader.obj_modelloaderMod.obj;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import handmadeguns.HandmadeGunsCore;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GLContext;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tracks client-side VBO mesh allocations for HMG OBJ models.
+ *
+ * VBOs are OpenGL objects owned by the current client context.  They must be
+ * created and deleted on the render/client thread while a valid GL context is
+ * current; OBJ parsing can happen on the existing background loader thread, but
+ * this cache intentionally compiles lazily from render() instead of during parse.
+ */
+@SideOnly(Side.CLIENT)
+public final class HMGVboModelCache {
+    private static final Set<HMGVboMeshGroup> MESHES = Collections.synchronizedSet(new HashSet<HMGVboMeshGroup>());
+    private static boolean loggedEnabled;
+    private static boolean loggedUnsupported;
+
+    private HMGVboModelCache() {
+    }
+
+    public static boolean isEnabled() {
+        if (!HandmadeGunsCore.enableVBOModelRendering) {
+            return false;
+        }
+
+        try {
+            boolean supported = GLContext.getCapabilities() != null && GLContext.getCapabilities().OpenGL15;
+            if (supported) {
+                if (!loggedEnabled) {
+                    System.out.println("HandmadeGuns-OBJ VBO rendering enabled");
+                    loggedEnabled = true;
+                }
+                return true;
+            }
+        } catch (Throwable ignored) {
+            // No current GL context yet, or LWJGL could not report capabilities.
+        }
+
+        if (!loggedUnsupported) {
+            System.out.println("HandmadeGuns-OBJ VBO rendering unavailable; using legacy OBJ display-list rendering");
+            loggedUnsupported = true;
+        }
+        return false;
+    }
+
+    static void register(HMGVboMeshGroup mesh) {
+        MESHES.add(mesh);
+    }
+
+    static void unregister(HMGVboMeshGroup mesh) {
+        MESHES.remove(mesh);
+    }
+
+    /**
+     * Releases all tracked VBOs.  Call from resource reload/model-cache clear or
+     * client shutdown while Minecraft's render context is still valid.
+     */
+    public static void releaseAll() {
+        HMGVboMeshGroup[] meshes;
+        synchronized (MESHES) {
+            meshes = MESHES.toArray(new HMGVboMeshGroup[MESHES.size()]);
+        }
+
+        int released = 0;
+        for (HMGVboMeshGroup mesh : meshes) {
+            if (mesh.release()) {
+                released++;
+            }
+        }
+
+        if (released > 0) {
+            System.out.println("HandmadeGuns-released " + released + " OBJ VBO buffer(s)");
+        }
+    }
+
+    static void bindArrayBuffer(int bufferId) {
+        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, bufferId);
+    }
+
+    static void deleteBuffer(int bufferId) {
+        GL15.glDeleteBuffers(bufferId);
+    }
+
+    static void resetClientState() {
+        bindArrayBuffer(0);
+        GL11.glDisableClientState(GL11.GL_VERTEX_ARRAY);
+        GL11.glDisableClientState(GL11.GL_NORMAL_ARRAY);
+        GL11.glDisableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+    }
+}

--- a/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGWavefrontObject.java
+++ b/HMG/src/main/java/handmadeguns/client/modelLoader/obj_modelloaderMod/obj/HMGWavefrontObject.java
@@ -162,6 +162,7 @@ public class HMGWavefrontObject implements IModelCustom_HMG
             }
 
             HMGGroupObjects.add(currentHMGGroupObject);
+            assignModelKeys();
         }
         catch (IOException e)
         {
@@ -185,6 +186,29 @@ public class HMGWavefrontObject implements IModelCustom_HMG
             catch (IOException e)
             {
                 // hush
+            }
+        }
+    }
+
+    private void assignModelKeys()
+    {
+        for (HMGGroupObject groupObject : HMGGroupObjects)
+        {
+            if (groupObject != null)
+            {
+                groupObject.setModelKey(fileName);
+            }
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void releaseVbos()
+    {
+        for (HMGGroupObject groupObject : HMGGroupObjects)
+        {
+            if (groupObject != null)
+            {
+                groupObject.releaseVbo();
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Reduce per-frame CPU tessellation and improve client FPS for HMG OBJ gun/attachment models by compiling static OBJ geometry into GPU VBOs when available. 
- Provide a safe, opt-out path that preserves existing display-list/legacy rendering and keeps higher-level gun animation and attachment logic unchanged. 
- Ensure VBO resources are created only with a valid GL context and cleaned up on resource reloads/shutdown to avoid GL buffer leaks. 

### Description
- Added a client config flag `enableVBOModelRendering` (default `true`) and wired it into the loader options via `HandmadeGunsCore` so users may disable the VBO path. 
- Introduced `HMGVboModelCache` to detect GL/GL15 support, track allocated VBOs, log enable/fallback/release events, and provide safe buffer deletion and client-state reset. 
- Implemented `HMGVboMeshGroup` which lazily compiles a group’s face data into an interleaved position/normal/UV `FloatBuffer`, creates a GL15 VBO, renders with client vertex/normal/texcoord arrays, and falls back on compile failure. 
- Hooked the VBO path into the existing OBJ pipeline by assigning model keys during `HMGWavefrontObject` parsing and attempting lazy compilation inside `HMGGroupObject.render()` while preserving the legacy display-list path; VBO compilation is intentionally lazy to run on the client render thread where a GL context is valid. 
- Added `HMGObjModelLoader.clearModelCache()` and `HMGGunMaker.clearCachedModels()` and a `HMGObjResourceReloadListener` which clears model caches and releases all VBOs on resource reloads; registered the reload listener from `ClientProxyHMG`. 
- Kept non-OBJ loaders and higher-level rendering/animation code unchanged (MQO/Techne paths and gun animation remain using existing behavior). 
- Added sparse, non-spammy logging for: VBO enabled state, per-group compilation success, per-group fallback reason, and VBO releases. 

### Testing
- Attempted to compile the mod with `./gradlew compileJava` which failed because the wrapper is not executable in the checkout. 
- Attempted `bash gradlew compileJava` but the environment blocked Gradle wrapper download due to a network/proxy `HTTP/1.1 403 Forbidden` error. 
- Attempted `gradle compileJava` with the system Gradle which failed during project configuration due to ForgeGradle/Gradle incompatibility for this workspace (build setup / missing Minecraft version); no successful compile artifacts were produced. 
- Runtime validation notes: VBO compilation is lazy and must run on the render thread with a valid GL context; if you run the built mod in a properly configured 1.7.10 Forge client the following runtime behaviors should be observed in logs: VBO enable message, per-model compile messages (once), fallback messages for unsupported/failed groups, and release messages on resource reload/exit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a263653aed88329b6a3dc66a8e9dfd4)